### PR TITLE
Refactoring explorer.go

### DIFF
--- a/explorer.go
+++ b/explorer.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-
-	wh "github.com/skycoin/skycoin/src/util/http"
 )
 
 const (
@@ -23,7 +21,7 @@ var (
 )
 
 func init() {
-	explorerHost = os.Getenv("SKYCOIN_EXPLORER_HOST")
+	explorerHost = os.Getenv("EXPLORER_HOST")
 	if explorerHost == "" {
 		explorerHost = defaultExplorerHost
 	}
@@ -36,7 +34,7 @@ func init() {
 	origURL, err := url.Parse(skycoinAddrString)
 	if err != nil {
 		log.Println("SKYCOIN_ADDR must have a scheme, e.g. http://")
-		log.Fatalln("Invalid SKYCOIN_HOST", skycoinAddrString, err)
+		log.Fatalln("Invalid SKYCOIN_ADDR", skycoinAddrString, err)
 	}
 
 	if origURL.Scheme == "" {
@@ -56,7 +54,7 @@ func init() {
 	}
 }
 
-func skycoinURL(path string, query url.Values) string {
+func buildSkycoinURL(path string, query url.Values) string {
 	rawQuery := ""
 	if query != nil {
 		rawQuery = query.Encode()
@@ -72,130 +70,97 @@ func skycoinURL(path string, query url.Values) string {
 	return u.String()
 }
 
-func relaySkycoinResponse(w http.ResponseWriter, r *http.Request, path string, query url.Values) {
-	u := skycoinURL(path, query)
-	log.Println("Skycoin node request:", u)
+type SkycoinProxyEndpoint struct {
+	ExplorerPath string
+	SkycoinPath  string
+	QueryArgs    []string
+}
 
-	resp, err := http.Get(u)
+func (s SkycoinProxyEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var query url.Values
+	if s.QueryArgs != nil {
+		query = url.Values{}
+		for _, s := range s.QueryArgs {
+			query.Add(s, r.URL.Query().Get(s))
+		}
+	}
+
+	skycoinURL := buildSkycoinURL(s.SkycoinPath, query)
+
+	log.Printf("Proxying request %s to skycoin node %s", r.URL.String(), skycoinURL)
+
+	resp, err := http.Get(skycoinURL)
 	if err != nil {
 		msg := "Request to skycoin node failed"
-		log.Println(msg)
-		wh.Error500(w, msg)
+		log.Println("ERROR:", msg, skycoinURL)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 
 	defer resp.Body.Close()
 
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		msg := "Error copying response from skycoin node to client"
-		log.Println(msg)
-		wh.Error500(w, msg)
+		msg := "Copying response from skycoin node to client failed"
+		log.Println("ERROR:", msg, skycoinURL)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 }
 
-func helloWorld(w http.ResponseWriter, r *http.Request) {
-	path := "/outputs"
-
-	relaySkycoinResponse(w, r, path, nil)
-}
-
-func getBlocks(w http.ResponseWriter, r *http.Request) {
-	path := "/blocks"
-
-	query := url.Values{}
-	query.Add("start", r.URL.Query().Get("start"))
-	query.Add("end", r.URL.Query().Get("end"))
-
-	relaySkycoinResponse(w, r, path, query)
-}
-
-func getSupply(w http.ResponseWriter, r *http.Request) {
-	path := "/explorer/getEffectiveOutputs"
-
-	relaySkycoinResponse(w, r, path, nil)
-}
-
-func getBlockChainMetaData(w http.ResponseWriter, r *http.Request) {
-	path := "/blockchain/metadata"
-
-	relaySkycoinResponse(w, r, path, nil)
-}
-
-func getAddress(w http.ResponseWriter, r *http.Request) {
-	path := "/explorer/address"
-
-	query := url.Values{}
-	query.Add("address", r.URL.Query().Get("address"))
-
-	relaySkycoinResponse(w, r, path, query)
-}
-
-func getCurrentBalance(w http.ResponseWriter, r *http.Request) {
-	path := "/outputs"
-
-	query := url.Values{}
-	query.Add("addrs", r.URL.Query().Get("address"))
-
-	relaySkycoinResponse(w, r, path, query)
-}
-
-func getUxID(w http.ResponseWriter, r *http.Request) {
-	path := "/uxout"
-
-	query := url.Values{}
-	query.Add("uxid", r.URL.Query().Get("uxid"))
-
-	relaySkycoinResponse(w, r, path, query)
-}
-
-func getTransaction(w http.ResponseWriter, r *http.Request) {
-	path := "/transaction"
-
-	query := url.Values{}
-	query.Add("txid", r.URL.Query().Get("txid"))
-
-	relaySkycoinResponse(w, r, path, query)
-}
-
-func getBlock(w http.ResponseWriter, r *http.Request) {
-	path := "/block"
-
-	query := url.Values{}
-	query.Add("hash", r.URL.Query().Get("hash"))
-
-	relaySkycoinResponse(w, r, path, query)
-}
-
-func logRequest(f http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("Handling API request path=%s", r.URL.Path)
-		f(w, r)
-	}
-}
-
-func handleAPIEndpoints() {
-	http.HandleFunc("/api/hello", logRequest(helloWorld))
-	http.HandleFunc("/api/blocks", logRequest(getBlocks))
-	http.HandleFunc("/api/blockchain/metadata", logRequest(getBlockChainMetaData))
-	http.HandleFunc("/api/address", logRequest(getAddress))
-	http.HandleFunc("/api/currentBalance", logRequest(getCurrentBalance))
-	http.HandleFunc("/api/uxout", logRequest(getUxID))
-	http.HandleFunc("/api/transaction", logRequest(getTransaction))
-	http.HandleFunc("/api/block", logRequest(getBlock))
-	http.HandleFunc("/api/coinSupply", logRequest(getSupply))
-
-}
-
-func handleStaticContent() {
-	http.Handle("/", http.FileServer(http.Dir("./dist/")))
+var proxyEndpoints = []SkycoinProxyEndpoint{
+	{
+		ExplorerPath: "/api/outputs",
+		SkycoinPath:  "/outputs",
+	},
+	{
+		ExplorerPath: "/api/block",
+		SkycoinPath:  "/block",
+		QueryArgs:    []string{"hash"},
+	},
+	{
+		ExplorerPath: "/api/blocks",
+		SkycoinPath:  "/blocks",
+		QueryArgs:    []string{"start", "end"},
+	},
+	{
+		ExplorerPath: "/api/coinSupply",
+		SkycoinPath:  "/explorer/getEffectiveOutputs",
+	},
+	{
+		ExplorerPath: "/api/blockchain/metadata",
+		SkycoinPath:  "/blockchain/metadata",
+	},
+	{
+		ExplorerPath: "/api/address",
+		SkycoinPath:  "/explorer/address",
+		QueryArgs:    []string{"address"},
+	},
+	{
+		ExplorerPath: "/api/currentBalance",
+		SkycoinPath:  "/outputs",
+		QueryArgs:    []string{"addrs"},
+	},
+	{
+		ExplorerPath: "/api/uxout",
+		SkycoinPath:  "/uxout",
+		QueryArgs:    []string{"uxid"},
+	},
+	{
+		ExplorerPath: "/api/transaction",
+		SkycoinPath:  "/transaction",
+		QueryArgs:    []string{"txid"},
+	},
 }
 
 func main() {
-	handleAPIEndpoints()
+	// Register proxy endpoints from config
+	for _, e := range proxyEndpoints {
+		http.Handle(e.ExplorerPath, e)
+		log.Printf("%s proxied to %s with args %v", e.ExplorerPath, e.SkycoinPath, e.QueryArgs)
+	}
 
 	if !apiOnly {
-		handleStaticContent()
+		http.Handle("/", http.FileServer(http.Dir("./dist/")))
 	}
 
 	log.Printf("Running skycoin explorer on http://%s", explorerHost)


### PR DESCRIPTION
* Default the host:port to `127.0.0.1:8001`
* Rename `SKYCOIN_HOST` envvar to `SKYCOIN_ADDR`
* Rename `SKYCOIN_EXPLORER_HOST` envvar to `EXPLORER_HOST`
* Configurable skycoin node proxy endpoints
* Better logging
* `/api/currentBalance` endpoint's query arg `address` renamed to `addrs` to match the skycoin node API
* `/api/hello` renamed to `/api/outputs`.  This endpoint might be unnecessary altogether. `/api/currentBalance` also calls the skycoin API's `/outputs` endpoint internally, albeit with a query arg.