### PR TITLE
Sort transactions newest to oldest

### DIFF
--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -25,13 +25,13 @@ export class AddressDetailComponent implements OnInit {
     this.route.params.switchMap((params: Params) => {
       this.address = params['address'];
       return this.explorer.getTransactions(this.address);
-    }).subscribe(transactions => {
-      //The order is reversed
-      for (let i:number = 0; i < transactions.length / 2; i++) {
-        let temp = transactions[i];
-        transactions[i] = transactions[transactions.length-(i+1)]
-        transactions[transactions.length-(i+1)] = temp;
-      }
+    }).subscribe(transactions => { 
+      //The transactions are ordered from the most recent to the oldest.
+      transactions.sort((t1:Transaction, t2:Transaction) => {
+        if (t1.timestamp > t2.timestamp) { return -1; }
+        if (t1.timestamp < t2.timestamp) { return 1; }
+        return 0;
+      });
       this.transactions = transactions;
     });
 

--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -27,12 +27,7 @@ export class AddressDetailComponent implements OnInit {
       return this.explorer.getTransactions(this.address);
     }).subscribe(transactions => { 
       //The transactions are ordered from the most recent to the oldest.
-      transactions.sort((t1:Transaction, t2:Transaction) => {
-        if (t1.timestamp > t2.timestamp) { return -1; }
-        if (t1.timestamp < t2.timestamp) { return 1; }
-        return 0;
-      });
-      this.transactions = transactions;
+      this.transactions = transactions.sort((a, b) => b.timestamp - a.timestamp);
     });
 
     this.route.params.switchMap((params: Params) => this.api.getCurrentBalance(params['address']))

--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -25,7 +25,15 @@ export class AddressDetailComponent implements OnInit {
     this.route.params.switchMap((params: Params) => {
       this.address = params['address'];
       return this.explorer.getTransactions(this.address);
-    }).subscribe(transactions => this.transactions = transactions);
+    }).subscribe(transactions => {
+      //The order is reversed
+      for (let i:number = 0; i < transactions.length / 2; i++) {
+        let temp = transactions[i];
+        transactions[i] = transactions[transactions.length-(i+1)]
+        transactions[transactions.length-(i+1)] = temp;
+      }
+      this.transactions = transactions;
+    });
 
     this.route.params.switchMap((params: Params) => this.api.getCurrentBalance(params['address']))
       .subscribe(response => this.balance = response.head_outputs.reduce((a, b) => a + parseFloat(b.coins), 0));


### PR DESCRIPTION
With this change, the transactions on the address screen are sorted starting with the most recent and ending with the oldest one. The change was made by inverting the order of the transactions, because the api of the nodes returns the list starting with the oldest transaction and endind with the newest. The new code was placed directly inside the code of the address screen and not inside the code that makes the connection to the api, so any other screen (existing or future) calling ExplorerService.getTransactions will receive the results with the default sorting returnen by the nodes (this is to avoid inconsistencies that may generate confusion in the future). Issues involved: https://github.com/skycoin/skycoin-explorer/issues/69 https://github.com/skycoin/skycoin/issues/752