### PR TITLE
Changes to the search mechanism

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -108,7 +108,7 @@ export class GetBlocksResponse {
   blocks: GetBlocksResponseBlock[];
 }
 
-class GetBlocksResponseBlock {
+export class GetBlocksResponseBlock {
   body: GetBlocksResponseBlockBody;
   header: GetBlocksResponseBlockHeader;
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { HeaderComponent } from './components/layout/header/header.component';
 import { SearchBarComponent } from './components/layout/search-bar/search-bar.component';
 import { LoadingComponent } from './components/layout/loading/loading.component';
 import { BlocksComponent } from './components/pages/blocks/blocks.component';
+import { SearchComponent } from './components/pages/search/search.component';
 import { ApiService } from './services/api/api.service';
 import { HttpModule } from '@angular/http';
 import { BlockDetailsComponent } from './components/pages/block-details/block-details.component';
@@ -15,6 +16,7 @@ import { TransactionDetailComponent } from './components/pages/transaction-detai
 import { AddressDetailComponent } from './components/pages/address-detail/address-detail.component';
 import { TransactionsValuePipe } from './pipes/transactions-value.pipe';
 import { ExplorerService } from './services/explorer/explorer.service';
+import { SearchDataService } from './services/search-data.service';
 import { QrCodeComponent } from './components/layout/qr-code/qr-code.component';
 import { FormsModule } from '@angular/forms';
 
@@ -44,6 +46,10 @@ const ROUTES = [
   {
     path: 'app/transaction/:txid',
     component: TransactionDetailComponent
+  },
+  {
+    path: 'app/search/:term',
+    component: SearchComponent
   }
   ,
 ];
@@ -54,6 +60,7 @@ const ROUTES = [
     AppComponent,
     BlockDetailsComponent,
     BlocksComponent,
+    SearchComponent,
     FooterComponent,
     HeaderComponent,
     LoadingComponent,
@@ -71,6 +78,7 @@ const ROUTES = [
   providers: [
     ApiService,
     ExplorerService,
+    SearchDataService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/layout/search-bar/search-bar.component.html
+++ b/src/app/components/layout/search-bar/search-bar.component.html
@@ -1,6 +1,6 @@
 <form (submit)="search()">
   <div class="-search-bar-container">
     <img src="/assets/img/search.png" (click)="search()">
-    <input [(ngModel)]="query" name="query" placeholder="Address, block number, or transaction ID">
+    <input [(ngModel)]="query" name="query" placeholder="Address, block hash, block number, or transaction ID">
   </div>
 </form>

--- a/src/app/components/layout/search-bar/search-bar.component.html
+++ b/src/app/components/layout/search-bar/search-bar.component.html
@@ -1,6 +1,6 @@
 <form (submit)="search()">
   <div class="-search-bar-container">
     <img src="/assets/img/search.png" (click)="search()">
-    <input [(ngModel)]="query" name="query" placeholder="Address, block hash, block number, or transaction ID">
+    <input [(ngModel)]="query" name="query" placeholder="Address, block hash, block number, or transaction ID" maxlength="70">
   </div>
 </form>

--- a/src/app/components/layout/search-bar/search-bar.component.ts
+++ b/src/app/components/layout/search-bar/search-bar.component.ts
@@ -14,7 +14,11 @@ export class SearchBarComponent {
   ) { }
 
   search() {
-    const hashVal = this.query.trim();
-    this.router.navigate(['/app/search', hashVal]);
+    if (this.query != undefined) {
+      const hashVal = this.query.trim();
+      if (hashVal.length > 0) {
+        this.router.navigate(['/app/search', hashVal]);
+      }
+    }
   }
 }

--- a/src/app/components/layout/search-bar/search-bar.component.ts
+++ b/src/app/components/layout/search-bar/search-bar.component.ts
@@ -15,13 +15,6 @@ export class SearchBarComponent {
 
   search() {
     const hashVal = this.query.trim();
-    if (hashVal.length === 34 || hashVal.length === 35 ) {
-      this.router.navigate(['/app/address', hashVal]);
-    } else if (hashVal.length === 64) {
-      this.router.navigate(['/app/transaction', hashVal]);
-    } else {
-      this.router.navigate(['/app/block', hashVal]);
-    }
-    this.query = null;
+    this.router.navigate(['/app/search', hashVal]);
   }
 }

--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -36,7 +36,10 @@ export class AddressDetailComponent implements OnInit {
       else
         return this.explorer.getTransactions(this.address);
 
-    }).subscribe(transactions => this.transactions = transactions);
+    }).subscribe(transactions => { 
+      //The transactions are ordered from the most recent to the oldest.
+      this.transactions = transactions.sort((a, b) => b.timestamp - a.timestamp);
+    });
 
     this.route.params.switchMap((params: Params) => this.api.getCurrentBalance(params['address']))
       .subscribe(response => this.balance = response.head_outputs.reduce((a, b) => a + parseFloat(b.coins), 0));

--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs/Rx';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { ApiService } from '../../../services/api/api.service';
 import { ExplorerService } from '../../../services/explorer/explorer.service';
-import { Output } from '../../../app.datatypes';
+import { Output, Transaction } from '../../../app.datatypes';
+import { SearchDataService } from '../../../services/search-data.service';
 
 @Component({
   selector: 'app-address-detail',
@@ -19,12 +21,21 @@ export class AddressDetailComponent implements OnInit {
     private explorer: ExplorerService,
     private route: ActivatedRoute,
     private router: Router,
+    private searchDataService: SearchDataService
   ) {}
 
   ngOnInit() {
     this.route.params.switchMap((params: Params) => {
       this.address = params['address'];
-      return this.explorer.getTransactions(this.address);
+
+      if (this.address == this.searchDataService.hash)
+        return Observable.create(obs => {
+          obs.next(this.searchDataService.data as Transaction[]);
+          obs.complete();
+        }) as Observable<Transaction[]>;
+      else
+        return this.explorer.getTransactions(this.address);
+
     }).subscribe(transactions => this.transactions = transactions);
 
     this.route.params.switchMap((params: Params) => this.api.getCurrentBalance(params['address']))

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -4,8 +4,8 @@
   <div class="block-details">
     <div class="-row"><span>Height</span> {{ block ? block.id : 'loading ..' }} </div>
     <div class="-row"><span>Timestamp</span> {{ block ? ((block.timestamp * 1000) | date: 'short') : 'loading ..' }} </div>
-    <div class="-row"><span>Hash</span> <span (click)="openBlock(block.id)">{{ block ? block.hash : 'loading ..' }}</span> </div>
-    <div class="-row"><span>Parent Hash</span> <span (click)="openBlock(block.id - 1)">{{ block && block.parent_hash ? block.parent_hash : 'loading ..' }}</span> </div>
+    <div class="-row"><span>Hash</span> <span (click)="openBlock(block.hash)">{{ block ? block.hash : 'loading ..' }}</span> </div>
+    <div class="-row"><span>Parent Hash</span> <span (click)="openBlock(block.parent_hash)">{{ block && block.parent_hash ? block.parent_hash : 'loading ..' }}</span> </div>
     <div class="-row"><span>Total Amount</span> {{ block ? (block.transactions | transactionsValue) + ' SKY' : 'loading ..' }} </div>
   </div>
   <div class="transactions" *ngIf="block && block.transactions.length >= 0">

--- a/src/app/components/pages/blocks/blocks.component.ts
+++ b/src/app/components/pages/blocks/blocks.component.ts
@@ -48,7 +48,7 @@ export class BlocksComponent implements OnInit {
   }
 
   open(block: Block) {
-    this.router.navigate(['/app/block', block.id]);
+    this.router.navigate(['/app/block', block.hash]);
   }
 
   navigate(pageIndex) {

--- a/src/app/components/pages/search/search.component.html
+++ b/src/app/components/pages/search/search.component.html
@@ -1,0 +1,6 @@
+<div class="row">
+  <div class="col-sm-6 -title">
+    <h2 *ngIf="error == false">Searching...</h2>
+    <h2 *ngIf="error == true">No results found</h2>
+  </div>
+</div>

--- a/src/app/components/pages/search/search.component.scss
+++ b/src/app/components/pages/search/search.component.scss
@@ -1,0 +1,10 @@
+@import '../../../../assets/scss/_variables.scss';
+
+h2 {
+  color: $primary;
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 42px;
+  margin-top: 40px;
+  text-align: left;
+}

--- a/src/app/components/pages/search/search.component.spec.ts
+++ b/src/app/components/pages/search/search.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchComponent } from './search.component';
+
+describe('SearchComponent', () => {
+  let component: SearchComponent;
+  let fixture: ComponentFixture<SearchComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/search/search.component.ts
+++ b/src/app/components/pages/search/search.component.ts
@@ -1,0 +1,65 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Params, Router } from '@angular/router';
+import { SearchDataService } from '../../../services/search-data.service';
+import { Block } from '../../../app.datatypes';
+import { ExplorerService } from '../../../services/explorer/explorer.service';
+import 'rxjs/add/operator/first';
+import 'rxjs/Subscription';
+
+class ResultsUrls {
+  static Address = "/app/address";
+  static Block = "/app/block";
+  static Transaction = "/app/transaction";
+}
+@Component({
+  templateUrl: './search.component.html',
+  styleUrls: ['./search.component.scss']
+})
+export class SearchComponent implements OnInit {
+
+  error = false;
+
+  constructor(
+    private explorer: ExplorerService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private searchDataService: SearchDataService
+  ) {}
+
+  ngOnInit() {
+    this.route.params.subscribe((params: Params) => {
+      if (params['term'].length === 64 )
+        this.searchTransaction(params['term'])
+      else if (params['term'].length === 34 || params['term'].length === 35 )
+        this.searchAddress(params['term'])
+      else
+        this.searchBlock(params['term'])
+    });
+  }
+
+  searchAddress(term:string) {
+    this.explorer.getTransactions(term)
+      .subscribe((transactions) => this.navigate(term, ResultsUrls.Address, transactions), (error: any) => this.searchBlockByHash(term));
+  }
+  searchTransaction(term:string) {
+    this.explorer.getTransaction(term)
+      .subscribe((transaction) => this.navigate(term, ResultsUrls.Transaction, transaction), (error: any) => this.searchBlockByHash(term));
+  }
+  searchBlockByHash(term:string) {
+    this.explorer.getBlockByHash(term)
+      .subscribe((block: Block) => this.navigate(term, ResultsUrls.Block, block), (error: any) => this.error = true);
+  }
+  searchBlock(term:string) {
+    if (isNaN(parseInt(term)))
+      this.error = true;
+    else
+      this.explorer.getBlock(parseInt(term))
+        .subscribe((block: Block) => this.navigate(block.hash, ResultsUrls.Block, block), (error: any) => this.error = true);
+  }
+
+  navigate(hash: string, page: string, recoveredData) {
+    this.searchDataService.hash = hash;
+    this.searchDataService.data = recoveredData;
+    this.router.navigate([page, hash], {replaceUrl:true});
+  }
+}

--- a/src/app/components/pages/search/search.component.ts
+++ b/src/app/components/pages/search/search.component.ts
@@ -34,6 +34,9 @@ export class SearchComponent implements OnInit {
         if (regexSha256.test(params['term'])) {
           this.searchTransaction(params['term']);
           return;
+        } else {
+          this.error = true;
+          return;
         }
       
       let termIsNumber = false;

--- a/src/app/components/pages/search/search.component.ts
+++ b/src/app/components/pages/search/search.component.ts
@@ -30,7 +30,7 @@ export class SearchComponent implements OnInit {
     this.route.params.subscribe((params: Params) => {
       if (params['term'].length === 64 )
         this.searchTransaction(params['term'])
-      else if (params['term'].length === 34 || params['term'].length === 35 )
+      else if (params['term'].length > 26 && params['term'].length < 35 )
         this.searchAddress(params['term'])
       else
         this.searchBlock(params['term'])

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.ts
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.ts
@@ -6,6 +6,7 @@ import moment from 'moment-es6';
 import 'rxjs/add/operator/mergeMap';
 import { Output, Transaction } from '../../../app.datatypes';
 import { ExplorerService } from '../../../services/explorer/explorer.service';
+import { SearchDataService } from '../../../services/search-data.service';
 
 @Component({
   selector: 'app-transaction-detail',
@@ -19,12 +20,21 @@ export class TransactionDetailComponent implements OnInit {
   constructor(
     private explorer: ExplorerService,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private searchDataService: SearchDataService
   ) {}
 
   ngOnInit() {
-    this.route.params.flatMap((params: Params) => this.explorer.getTransaction(params['txid']))
-      .subscribe(transaction => this.transaction = transaction);
+    this.route.params. flatMap((params: Params) => {
+        if (params['txid'] == this.searchDataService.hash)
+          return Observable.create(obs => {
+            obs.next(this.searchDataService.data as Transaction);
+            obs.complete();
+          }) as Observable<Transaction>;
+        else
+          return this.explorer.getTransaction(params['txid'])
+      })
+      .subscribe(transaction => {this.searchDataService.hash = null, this.transaction = transaction});
   }
 
   openAddress(output: Output) {

--- a/src/app/services/api/api.service.ts
+++ b/src/app/services/api/api.service.ts
@@ -6,7 +6,7 @@ import 'rxjs/add/operator/catch';
 
 import { CoinSupply } from '../../components/pages/blocks/block';
 import { AddressBalanceResponse, UnspentOutput } from '../../components/pages/address-detail/UnspentOutput';
-import { Block, Blockchain, GetBlocksResponse, GetBlockchainMetadataResponse, parseGetBlocksBlock, GetUxoutResponse, GetAddressResponseTransaction, GetCurrentBalanceResponse } from '../../app.datatypes';
+import { Block, Blockchain, GetBlocksResponse, GetBlocksResponseBlock, GetBlockchainMetadataResponse, parseGetBlocksBlock, GetUxoutResponse, GetAddressResponseTransaction, GetCurrentBalanceResponse } from '../../app.datatypes';
 
 @Injectable()
 export class ApiService {
@@ -23,6 +23,10 @@ export class ApiService {
 
   getBlocks(startNumber: number, endNumber: number): Observable<GetBlocksResponse> {
     return this.get('blocks', { start: startNumber, end: endNumber });
+  }
+
+  getBlock(hash: string): Observable<GetBlocksResponseBlock> {
+    return this.get('block', { hash: hash });
   }
 
   getBlockchainMetadata(): Observable<Blockchain> {
@@ -57,7 +61,7 @@ export class ApiService {
   private get(url, options = null) {
     return this.http.get(this.getUrl(url, options))
       .map((res: any) => res.json())
-      .catch((error: any) => Observable.throw(error || 'Server error'));
+      .catch((error: any) => Observable.throw(error || 'Server error') );
   }
 
   private getQueryString(parameters = null) {

--- a/src/app/services/explorer/explorer.service.ts
+++ b/src/app/services/explorer/explorer.service.ts
@@ -25,6 +25,10 @@ export class ExplorerService {
     });
   }
 
+  getBlockByHash(hash: string): Observable<Block> {
+    return this.api.getBlock(hash).map(response => parseGetBlocksBlock(response));
+  }
+
   getBlocks(start: number, end: number): Observable<Block[]> {
     return this.api.getBlocks(start, end)
       .map(response => response.blocks.map(block => parseGetBlocksBlock(block)).sort((a, b) => b.id - a.id));

--- a/src/app/services/search-data.service.ts
+++ b/src/app/services/search-data.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class SearchDataService  {
+  hash:string = null;
+  data:any = null;
+}


### PR DESCRIPTION
In issue https://github.com/skycoin/skycoin-explorer/issues/59 the ability to search by block hash was requested. However, the change was not easy to implement because there is no way to distinguish the transaction hashes from the block hashes and the browser simply redirected the user to the screen of the type of data searched (not knowing if the hash was from a block or a transaction there was no way to redirect the user correctly). Due to all this, changes were made to the search system.

Now, when performing a search, the user is redirected to an intermediate screen that simply says "searching". In case the user searches for an address or a block number, the screen simply performs the search and, if successful, redirects the user to the corresponding screen (the searched data is stored in a service to avoid unnecessarily repeat the search after the redirection). If the search is not successful, "No results found" is shown. Redirections from the intermediate search screen do not affect the correct functioning of the "back" button of the browser.

If the user searches for a 64-character hash, the search screen first tries to find the transaction that matches that hash and then, if it does not find it, it tries to find the block that matches that hash (as was suggested in https://github.com/skycoin/skycoin-explorer/issues/59 ). If a transaction or block is found, the user is redirected accordingly, if not, "No results found" is shown.