### PR TITLE
Add formatting info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,30 @@ installing node and npm then running `npm install` and `npm run build`.
 make build-ng
 ```
 
+### Formatting
+
+`explorer.go` should be formatted with `goimports`. You can do this with:
+
+```sh
+make format
+```
+
+You must have goimports installed (use `make install-linters`).
+
+### Code Linting
+
+Install prerequisites:
+
+```sh
+make install-linters
+```
+
+Run linters:
+
+```sh
+make lint
+```
+
 ## Deployment
 
 Compile `explorer.go` to a binary:


### PR DESCRIPTION
Info about `make format`, `make install-linters` and `make lint` (added in https://github.com/skycoin/skycoin-explorer/pull/97)