### PR TITLE
Fix double click selection

### DIFF
--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -6,8 +6,8 @@
       <app-qr-code [string]="address" *ngIf="address"></app-qr-code>
       <span>Address</span><br class="-xs-only" /> {{ address ? address : loadingMsg }}
     </div>
-    <div class="-row -tx-number"><span># of Transactions</span><br class="-xs-only" /> {{ transactions ? transactions.length : loadingMsg }} </div>
-    <div class="-row"><span>Balance</span><br class="-xs-only" /> {{ transactions ? ( balance | number:'1.0-6') : loadingMsg }} </div>
+    <div class="-row -tx-number"><span># of Transactions</span><br class="-xs-only" /><div> {{ transactions ? transactions.length : loadingMsg }} </div></div>
+    <div class="-row"><span>Balance</span><br class="-xs-only" /><div> {{ transactions ? ( balance | number:'1.0-6') : loadingMsg }} </div></div>
   </div>
 </div>
 <div class="-qr-code -not-xs">
@@ -28,8 +28,8 @@
     <div class="row">
       <div class="col-md-9 col-sm-12">
         <div class="-row">
-          Transaction ID<span class="-xs-sm-only">:<br/></span>
-          <a [routerLink]="'/app/transaction/' + transaction.id">{{ transaction.id }}</a>
+          <div class="-float-left">Transaction ID<span class="-xs-sm-only">:</span></div><br class="-xs-sm-only"/>
+          <div class="-address"><a [routerLink]="'/app/transaction/' + transaction.id">{{ transaction.id }}</a></div>
           <br class="-xs-sm-only" />
           <div class="-label" [ngClass]="{'-red' : transaction.balance < 0, '-green' : transaction.balance >= 0}">
             {{ (transaction.balance<0?"":"+")+(transaction.balance | number:'1.0-6') }} SKY <ng-container *ngIf="!transaction.status">(pending)</ng-container>
@@ -42,8 +42,8 @@
 
   <div class="-header -not-xs">
     <div class="row">
-      <div class="col-sm-6">Inputs</div>
-      <div class="col-sm-6">Outputs</div>
+      <div class="col-sm-6"><div>Inputs</div></div>
+      <div class="col-sm-6"><div>Outputs</div></div>
     </div>
   </div>
   <div class="-data">
@@ -52,21 +52,21 @@
         <div class="-header -xs-only">Inputs</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
           {{ input.hash }}
-          <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
+          <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ input.coins | number:'1.0-6' }}</div></div>
         </div>
       </div>
       <div class="col-sm-6">
         <div class="-header -xs-only">Outputs</div>
         <div class="-body" *ngFor="let output of transaction.outputs">
           <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a>
-          <div class="-balance"><span class="-transparent">Coins:</span> {{ output.coins | number:'1.0-6' }}</div>
+          <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
         </div>
       </div>
     </div>
     <div class="row">
       <div class="col-sm-12">
         <div class="-header -xs-only">Final address balance</div>
-        <div class="-final-balance -right"><span class="-transparent -not-xs">Final address balance: </span><span class="-transparent -xs-only">Coins: </span>{{ transaction.addressBalance | number:'1.0-6' }}</div>
+        <div class="-final-balance"><div><div class="-transparent -not-xs -float-left">Final address balance:&nbsp;</div><div class="-transparent -xs-only -float-left">Coins:&nbsp;</div><div>{{ transaction.addressBalance | number:'1.0-6' }}</div></div></div>
       </div>
     </div>
   </div>

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -1,11 +1,11 @@
 <div class="element-details-wrapper">
   <h2>Block Details</h2>
   <div class="element-details">
-    <div class="-row"><span>Height</span><br class="-xs-only" /> {{ block ? block.id : loadingMsg }} </div>
-    <div class="-row"><span>Timestamp</span><br class="-xs-only" /> {{ block ? ((block.timestamp * 1000) | date: 'short') : loadingMsg }} </div>
-    <div class="-row"><span>Hash</span><br class="-xs-only" /> <a [routerLink]="'/app/block/' + block.id" class="-link" *ngIf="block">{{ block.hash }}</a> <span *ngIf="!block">{{ loadingMsg }}</span> </div>
-    <div class="-row"><span>Parent Hash</span><br class="-xs-only" /> <a [routerLink]="'/app/block/' + (block.id-1)" class="-link" *ngIf="block && block.parent_hash">{{ block.parent_hash }}</a> <span *ngIf="block && !block.parent_hash">Without parent block</span> <span *ngIf="!block">{{ loadingMsg }}</span> </div>
-    <div class="-row"><span>Total Amount</span><br class="-xs-only" /> {{ block ? ((block.transactions | transactionsValue) | number:'1.0-6') + ' SKY' : loadingMsg }} </div>
+    <div class="-row"><span>Height</span><br class="-xs-only" /><div> {{ block ? block.id : loadingMsg }} </div></div>
+    <div class="-row"><span>Timestamp</span><br class="-xs-only" /><div> {{ block ? ((block.timestamp * 1000) | date: 'short') : loadingMsg }} </div></div>
+    <div class="-row"><span>Hash</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + block.id" class="-link" *ngIf="block">{{ block.hash }}</a> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
+    <div class="-row"><span>Parent Hash</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + (block.id-1)" class="-link" *ngIf="block && block.parent_hash">{{ block.parent_hash }}</a> <span *ngIf="block && !block.parent_hash">Without parent block</span> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
+    <div class="-row"><span>Total Amount</span><br class="-xs-only" /><div> {{ block ? ((block.transactions | transactionsValue) | number:'1.0-6') + ' SKY' : loadingMsg }} </div></div>
   </div>
 </div>
 
@@ -24,8 +24,8 @@
       <div class="row">
         <div class="col-md-8 col-sm-12">
           <div class="-row">
-            Transaction ID<span class="-xs-sm-only">:<br/></span>
-            <a [routerLink]="'/app/transaction/' + transaction.id" *ngIf="transaction">{{ transaction.id }}</a>
+            <div class="-float-left">Transaction ID<span class="-xs-sm-only">:</span></div><br class="-xs-sm-only"/>
+            <div><a [routerLink]="'/app/transaction/' + transaction.id" *ngIf="transaction">{{ transaction.id }}</a></div>
           </div>
         </div>
       </div>
@@ -33,8 +33,8 @@
 
     <div class="-header -not-xs">
       <div class="row">
-        <div class="col-sm-6">Inputs</div>
-        <div class="col-sm-6">Outputs</div>
+        <div class="col-sm-6"><div>Inputs</div></div>
+        <div class="col-sm-6"><div>Outputs</div></div>
       </div>
     </div>
     <div class="-data">
@@ -43,14 +43,14 @@
           <div class="-header -xs-only">Inputs</div>
           <div class="-body" *ngFor="let input of transaction.inputs">
             {{ input.hash }}
-            <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
+            <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ input.coins | number:'1.0-6' }}</div></div>
           </div>
         </div>
         <div class="col-sm-6">
           <div class="-header -xs-only">Outputs</div>
           <div class="-body" *ngFor="let output of transaction.outputs">
             <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a>
-            <div class="-balance"><span class="-transparent">Coins:</span> {{ output.coins | number:'1.0-6' }}</div>
+            <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
           </div>
         </div>
       </div>

--- a/src/app/components/pages/blocks/blocks.component.html
+++ b/src/app/components/pages/blocks/blocks.component.html
@@ -4,11 +4,11 @@
     <h2 class="-xs-only">Stats</h2>
   </div>
   <div class="col-sm-6 -details">
-    <p><span class="-label">Block Height:</span> <span class="-value">{{ blockCount > 0 ? (blockCount | number : '1.0-0') : loadingMetadataMsg }}</span> </p>
-    <p><span class="-label">Current Supply:</span> <span class="-value">{{ currentSupply ? (currentSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span> </p>
-    <p><span class="-label">Total Supply:</span> <span class="-value">{{ totalSupply ? (totalSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span> </p>
-    <p><span class="-label">Current Coinhour Supply:</span> <span class="-value">{{ currentCoinhourSupply ? (currentCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span> </p>
-    <p><span class="-label">Total Coinhour Supply:</span> <span class="-value">{{ totalCoinhourSupply ? (totalCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span> </p>
+    <p><span><span class="-label">Block Height:</span> <span class="-value">{{ blockCount > 0 ? (blockCount | number : '1.0-0') : loadingMetadataMsg }}</span></span></p>
+    <p><span><span class="-label">Current Supply:</span> <span class="-value">{{ currentSupply ? (currentSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">Total Supply:</span> <span class="-value">{{ totalSupply ? (totalSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">Current Coinhour Supply:</span> <span class="-value">{{ currentCoinhourSupply ? (currentCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">Total Coinhour Supply:</span> <span class="-value">{{ totalCoinhourSupply ? (totalCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
     <p><a routerLink="/app/unconfirmedtransactions" class="-link">Unconfirmed Transactions</a></p>
   </div>
 </div>

--- a/src/app/components/pages/blocks/blocks.component.scss
+++ b/src/app/components/pages/blocks/blocks.component.scss
@@ -15,9 +15,14 @@
     padding: 3px 0;
     margin-bottom: 5px;
 
-    .-label {
+    >span:first-child {
       display: inline-block;
+    }
+
+    .-label {
+      display: block;
       opacity: $transparent;
+      float: left;
     }
 
     .-link {

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -1,9 +1,9 @@
 <div class="element-details-wrapper">
   <h2>Transaction</h2>
   <div class="element-details">
-    <div class="-row"><span>Status</span><br class="-xs-only" /> {{ transaction ? (transaction.status ? 'Confirmed' : 'Unconfirmed') : loadingMsg }} </div>
-    <div class="-row"><span>Timestamp</span><br class="-xs-only" /> {{ transaction ? (transaction.timestamp * 1000 | date: 'short') : loadingMsg }} </div>
-    <div class="-row"><span>Block</span><br class="-xs-only" /> {{ transaction ? transaction.block : loadingMsg }} </div>
+    <div class="-row"><span>Status</span><br class="-xs-only" /><div> {{ transaction ? (transaction.status ? 'Confirmed' : 'Unconfirmed') : loadingMsg }} </div></div>
+    <div class="-row"><span>Timestamp</span><br class="-xs-only" /><div> {{ transaction ? (transaction.timestamp * 1000 | date: 'short') : loadingMsg }} </div></div>
+    <div class="-row"><span>Block</span><br class="-xs-only" /><div> {{ transaction ? transaction.block : loadingMsg }} </div></div>
   </div>
 </div>
 
@@ -21,9 +21,9 @@
     <div class="row">
       <div class="col-md-8 col-sm-12">
         <div class="-row">
-          Transaction ID<span class="-xs-sm-only">:<br/></span>
-          <a [routerLink]="'/app/transaction/' + transaction.id" *ngIf="transaction">{{ transaction.id }}</a>
-          <span *ngIf="transaction === undefined">{{ loadingMsg }}</span>
+          <div class="-float-left">Transaction ID<span class="-xs-sm-only">:</span></div><br class="-xs-sm-only"/>
+          <div><a [routerLink]="'/app/transaction/' + transaction.id" *ngIf="transaction">{{ transaction.id }}</a></div>
+          <div *ngIf="transaction === undefined">{{ loadingMsg }}</div>
         </div>
       </div>
       <div class="col-md-4 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">Date:<br/></span>{{ transaction ? (transaction.timestamp * 1000 | date: 'short') : loadingMsg }}</div></div>
@@ -32,8 +32,8 @@
 
   <div class="-header -not-xs">
     <div class="row">
-      <div class="col-sm-6">Inputs</div>
-      <div class="col-sm-6">Outputs</div>
+      <div class="col-sm-6"><div>Inputs</div></div>
+      <div class="col-sm-6"><div>Outputs</div></div>
     </div>
   </div>
   <div class="-data">
@@ -42,14 +42,14 @@
         <div class="-header -xs-only">Inputs</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
           {{ input.hash }}
-          <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
+          <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ input.coins | number:'1.0-6' }}</div></div>
         </div>
       </div>
       <div class="col-sm-6">
         <div class="-header -xs-only">Outputs</div>
         <div class="-body" *ngFor="let output of transaction.outputs">
           <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a>
-          <div class="-balance"><span class="-transparent">Coins:</span> {{ output.coins | number:'1.0-6' }}</div>
+          <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
         </div>
       </div>
     </div>

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
@@ -1,9 +1,9 @@
 <div class="element-details-wrapper">
   <h2>Unconfirmed Transactions</h2>
   <div class="element-details">
-    <div class="-row"><span>Quantity</span><br class="-xs-only" /> {{ transactions ? (transactions.length > 0 ? transactions.length : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div>
-    <div class="-row"><span>Newest</span><br class="-xs-only" /> {{ transactions ? (transactions.length > 0 ? (mostRecent | date: 'short') : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div>
-    <div class="-row"><span>Oldest</span><br class="-xs-only" /> {{ transactions ? (transactions.length > 0 ? (leastRecent | date: 'short') : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div>
+    <div class="-row"><span>Quantity</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? transactions.length : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
+    <div class="-row"><span>Newest</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (mostRecent | date: 'short') : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
+    <div class="-row"><span>Oldest</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (leastRecent | date: 'short') : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
   </div>
 </div>
 
@@ -21,9 +21,9 @@
     <div class="row">
       <div class="col-md-8 col-sm-12">
         <div class="-row">
-          Transaction ID<span class="-xs-sm-only">:<br/></span>
-          <a [routerLink]="'/app/transaction/' + transaction.id" *ngIf="transaction">{{ transaction.id }}</a>
-          <span *ngIf="transaction === undefined">{{ loadingMsg }}</span>
+          <div class="-float-left">Transaction ID<span class="-xs-sm-only">:</span></div><br class="-xs-sm-only"/>
+          <div><a [routerLink]="'/app/transaction/' + transaction.id" *ngIf="transaction">{{ transaction.id }}</a></div>
+          <div *ngIf="transaction === undefined">{{ loadingMsg }}</div>
         </div>
       </div>
       <div class="col-md-4 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">First seen at:<br/></span>{{ transaction ? (transaction.timestamp * 1000 | date: 'short') : loadingMsg }}</div></div>
@@ -32,8 +32,8 @@
 
   <div class="-header -not-xs">
     <div class="row">
-      <div class="col-sm-6">Inputs</div>
-      <div class="col-sm-6">Outputs</div>
+      <div class="col-sm-6"><div>Inputs</div></div>
+      <div class="col-sm-6"><div>Outputs</div></div>
     </div>
   </div>
   <div class="-data">
@@ -48,7 +48,7 @@
         <div class="-header -xs-only">Outputs</div>
         <div class="-body" *ngFor="let output of transaction.outputs">
           <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a>
-          <div class="-balance"><span class="-transparent">Coins:</span> {{ output.coins | number:'1.0-6' }}</div>
+          <div class="-balance"><div class="-transparent -float-left">Coins:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
         </div>
       </div>
     </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,10 @@ h2 {
   text-align: left;
 }
 
+.-float-left {
+  float: left;
+}
+
 .element-details-wrapper {
 
   width: 100%;
@@ -36,8 +40,9 @@ h2 {
         padding-top: 0;
       }
 
-      span:first-child {
-        display: inline-block;
+      > span:first-child {
+        display: block;
+        float: left;
         opacity: $transparent;
         width: 110px;
       }
@@ -95,6 +100,9 @@ h2 {
       padding: 2px 15px;
       color: white;
     }
+    .-address {
+      float: left;
+    }
   
     @media (max-width: $max-sm-width) {
       a {
@@ -105,6 +113,10 @@ h2 {
       }
       .-label {
         margin: 5px 0px 0px 0px;
+      }
+      .-address {
+        float: none;
+        display: inline;
       }
 
       .row {
@@ -172,6 +184,13 @@ h2 {
       border-top: 1px solid $col-normal-separator;
       padding: $siz-small-margin 0px;
       text-align: right;
+
+      > div {
+        display: inline-block;
+        > div:last-child {
+          display: inline-block;
+        }
+      }
 
       @media (max-width: $max-xs-width) {
         & {


### PR DESCRIPTION
Solves https://github.com/skycoin/skycoin-explorer/issues/81 . The modifications on this pr are not only to fix the problems while selecting the addresses and dates, but also for making easier to select most of the important data. This includes the data of the blockchain in the initial screen, the details of the transactions, etc. However, selecting the text of the links by double clicking can still be a bit complicated, so it may be good to add buttons for copying.

The changes were a bit long due to differences in the operation of the different explorers. The changes were tested in recent versions of Chrome, Firefox and Edge.