### PR TITLE
Show the input addresses

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -45,14 +45,6 @@ export class Transaction {
   addressBalance: number;
 }
 
-export class UnconfirmedTransaction {
-  id: string;
-  inputs: string[];
-  outputs: Output[];
-  valid: boolean;
-  timestamp: number;
-}
-
 export class Wallet {
   label: string;
   addresses: Address[];
@@ -144,13 +136,16 @@ export class GetUnconfirmedTransactionBody {
   outputs: GetAddressResponseTransactionOutput[];
 }
 
-export function parseGetUnconfirmedTransaction(raw: GetUnconfirmedTransaction): UnconfirmedTransaction {
+export function parseGetUnconfirmedTransaction(raw: GetUnconfirmedTransaction): Transaction {
   return {
+    block: null,
     id: raw.transaction.txid,
-    inputs: raw.transaction.inputs,
+    inputs: raw.transaction.inputs.map(input => ({ address: null, coins: null, hash: input, hours: null })),
     outputs: raw.transaction.outputs.map(output => parseGetAddressOutput(output)),
-    valid: raw.is_valid,
+    status: raw.is_valid,
     timestamp: new Date(raw.received).getTime(),
+    balance: null,
+    addressBalance: null,
   }
 }
 

--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -51,7 +51,7 @@
       <div class="col-sm-6">
         <div class="-header -xs-only">Inputs</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
-          {{ input.hash }}
+          <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a>
           <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
         </div>
       </div>

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -42,7 +42,7 @@
         <div class="col-sm-6">
           <div class="-header -xs-only">Inputs</div>
           <div class="-body" *ngFor="let input of transaction.inputs">
-            {{ input.hash }}
+            <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a>
             <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
           </div>
         </div>

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -41,7 +41,7 @@
       <div class="col-sm-6">
         <div class="-header -xs-only">Inputs</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
-          {{ input.hash }}
+          <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a>
           <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
         </div>
       </div>

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
@@ -41,7 +41,8 @@
       <div class="col-sm-6">
         <div class="-header -xs-only">Inputs</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
-          {{ input }}
+          <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a>
+          <div class="-balance"><span class="-transparent">Coins:</span> {{ input.coins | number:'1.0-6' }}</div>
         </div>
       </div>
       <div class="col-sm-6">

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.ts
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { ExplorerService } from '../../../services/explorer/explorer.service';
-import { Output, UnconfirmedTransaction } from '../../../app.datatypes';
+import { Output, Transaction } from '../../../app.datatypes';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/switchMap';
 
@@ -12,7 +12,7 @@ import 'rxjs/add/operator/switchMap';
 })
 export class UnconfirmedTransactionsComponent implements OnInit {
 
-  transactions: UnconfirmedTransaction[];
+  transactions: Transaction[];
   leastRecent: number;
   mostRecent: number;
   loadingMsg = "Loading...";


### PR DESCRIPTION
Solves https://github.com/skycoin/skycoin-explorer/issues/111 and https://github.com/skycoin/skycoin-explorer/issues/114 .

The addresses are obtained with a workaround already present in the explorer (except while quering addresses, the node's api does not return addresses of the inputs, only the hashes), so the performance remains the same as before. However, the procedure will be more efficient with the changes indicated in the two issues solved by this pr.

Now transactions look like this:
![tx](https://user-images.githubusercontent.com/34079003/37416755-08a450d0-2785-11e8-8760-6869b74bf757.png)
