### PR TITLE
Send logs to stdout

### DIFF
--- a/explorer.go
+++ b/explorer.go
@@ -57,6 +57,8 @@ var (
 )
 
 func init() {
+	log.SetOutput(os.Stdout)
+
 	explorerHost = os.Getenv("EXPLORER_HOST")
 	if explorerHost == "" {
 		explorerHost = defaultExplorerHost


### PR DESCRIPTION
Solves https://github.com/skycoin/skycoin-explorer/issues/49

It is a single line of code that sends to stdout all messages sent by `log`, so the change works automatically without changing the rest of the code. However, if you find it better replace the direct calls to the `log` package with a new log object with a name like `stdoutLog` (for readability reasons), it can be done.