### PR TITLE
Small improvements for the lists

### DIFF
--- a/src/app/components/pages/blocks/blocks.component.html
+++ b/src/app/components/pages/blocks/blocks.component.html
@@ -18,10 +18,10 @@
 <div class="table">
   <div class="-header">
     <div class="row">
-      <div class="col-sm-2 col-xs-4">Time</div>
-      <div class="col-sm-2 col-xs-4">Block Number</div>
-      <div class="col-sm-2 col-xs-4">Transactions</div>
-      <div class="col-sm-6 -fix-left -not-xs">Blockhash</div>
+      <div class="col-sm-2 col-xs-4"><div>Time</div></div>
+      <div class="col-sm-2 col-xs-4"><div>Block Number</div></div>
+      <div class="col-sm-2 col-xs-4"><div>Transactions</div></div>
+      <div class="col-sm-6 -fix-left -not-xs"><div>Blockhash</div></div>
     </div>
   </div>
   <div class="row -msg-container" *ngIf="!blocks.length">

--- a/src/app/components/pages/richlist/richlist.component.html
+++ b/src/app/components/pages/richlist/richlist.component.html
@@ -3,9 +3,9 @@
 <div class="table">
   <div class="-header">
     <div class="row">
-      <div class="col-sm-1 -not-xs">#</div>
-      <div class="col-xs-6 col-sm-8">Address</div>
-      <div class="col-xs-6 col-sm-3">Coins</div>
+      <div class="col-sm-1 -not-xs"><div>#</div></div>
+      <div class="col-xs-6 col-sm-8"><div>Address</div></div>
+      <div class="col-xs-6 col-sm-3"><div>Coins</div></div>
     </div>
   </div>
   <div class="row -msg-container" *ngIf="!entries.length">

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -11,7 +11,9 @@ $transparent: 0.25;
 
 $col-hard-background: #F0F0F0;
 $col-normal-background: #fff;
+$col-normal-background-hover: #F7F7F7;
 $col-odd-background: rgb(244, 249, 255);
+$col-odd-background-hover: rgb(241, 246, 252);
 $col-soft-background: #FBFBFB;
 $col-hard-separator: #E2E2E2;
 $col-normal-separator: #EFF0F0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -237,10 +237,17 @@ h2 {
 
     &:nth-child(even) {
       background-color: $col-odd-background;
+      &:hover {
+        background-color: $col-odd-background-hover;
+      }
     }
 
     .-gray {
       color: #92A4BA;
+    }
+
+    &:hover {
+      background-color: $col-normal-background-hover;
     }
   }
 


### PR DESCRIPTION
This pr affects the block lists and the rich list.

The first change is a simple fix for a problem with the text selection that happened when double-clicking on the list header (it was not resolved in talll to avoid conflicts with others pr). 

The other change is that the rows of the tables are highlighted when the mouse is over them. This is to improve the usability, since all the other links are underlined when the mouse is over them, while the rows of the list do not have any visual clue indicating that they are clickable links.
