### PR TITLE
Transactions pagination

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,6 +41,11 @@ const ROUTES = [
   },
   {
     path: 'app/address/:address',
+    redirectTo: 'app/address/:address/1',
+    pathMatch: 'full'
+  },
+  {
+    path: 'app/address/:address/:page',
     component: AddressDetailComponent
   },
   {

--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<div class="transaction" *ngFor="let transaction of transactions">
+<div class="transaction" *ngFor="let transaction of pageTransactions">
   <div class="-title">
     <div class="row">
       <div class="col-md-9 col-sm-12">
@@ -70,4 +70,16 @@
       </div>
     </div>
   </div>
+</div>
+
+<div class="pagination" *ngIf="transactions && transactions.length > pageSize">
+  <a class="-first" [ngClass]="{ disabled: pageIndex <= 0 }" [routerLink]="'/app/address/' + address + '/1'">«</a>
+  <a class="-previous" [ngClass]="{ disabled: pageIndex <= 0 }" [routerLink]="'/app/address/' + address + '/' + (pageIndex > 0 ? pageIndex : 1)">‹</a>
+  <a class="-page -hide-xs" *ngIf="pageIndex > 1" [routerLink]="'/app/address/' + address + '/' + (pageIndex - 1)">{{ pageIndex - 1 }}</a>
+  <a class="-page" *ngIf="pageIndex > 0" [routerLink]="'/app/address/' + address + '/' + pageIndex">{{ pageIndex }}</a>
+  <a class="-page disabled">{{ pageIndex + 1 }}</a>
+  <a class="-page" *ngIf="pageIndex < pageCount - 1" [routerLink]="'/app/address/' + address + '/' + (pageIndex + 2)">{{ pageIndex + 2 }}</a>
+  <a class="-page -hide-xs" *ngIf="pageIndex < pageCount - 2" [routerLink]="'/app/address/' + address + '/' + (pageIndex + 3)">{{ pageIndex + 3 }}</a>
+  <a class="-next" [ngClass]="{ disabled: pageIndex >= pageCount - 1 }" [routerLink]="'/app/address/' + address + '/' + (pageIndex + 2 < pageCount ? pageIndex + 2 : pageCount)">›</a>
+  <a class="-last" [ngClass]="{ disabled: pageIndex >= pageCount - 1 }" [routerLink]="'/app/address/' + address + '/' + pageCount">»</a>
 </div>

--- a/src/app/components/pages/blocks/blocks.component.scss
+++ b/src/app/components/pages/blocks/blocks.component.scss
@@ -37,38 +37,3 @@
     }
   }
 }
-
-.pagination {
-  margin-top: $siz-big-margin;
-  text-align: right;
-  font-size: $siz-normal-text;
-
-  a {
-    background-color: $col-soft-background;
-    border: 1px solid $col-normal-separator;
-    cursor: pointer;
-    display: inline-block;
-    height: 30px;
-    line-height: 28px;
-    min-width: 30px;
-    text-align: center;
-    text-decoration: none;
-    user-select: none;
-    -moz-user-select: none;
-    -khtml-user-select: none;
-    -webkit-user-select: none;
-    -o-user-select: none;
-
-    &.disabled {
-      background-color: $col-soft-background;
-      color: #cdcdcd;
-      cursor: not-allowed;
-    }
-  }
-
-  @media (max-width: $max-xs-width) {
-    .-hide-xs {
-      display: none;
-    }
-  }
-}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -256,3 +256,38 @@ h2 {
     padding: 24px 0;
   }
 }
+
+.pagination {
+  margin-top: $siz-big-margin;
+  text-align: right;
+  font-size: $siz-normal-text;
+
+  a {
+    background-color: $col-soft-background;
+    border: 1px solid $col-normal-separator;
+    cursor: pointer;
+    display: inline-block;
+    height: 30px;
+    line-height: 28px;
+    min-width: 30px;
+    text-align: center;
+    text-decoration: none;
+    user-select: none;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -o-user-select: none;
+
+    &.disabled {
+      background-color: $col-soft-background;
+      color: #cdcdcd;
+      cursor: not-allowed;
+    }
+  }
+
+  @media (max-width: $max-xs-width) {
+    .-hide-xs {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
This solves part of https://github.com/skycoin/skycoin-explorer/issues/89

As indicated in the issue, the address screen takes a long time to load if the address has many transactions. The slowness is due to two things: the need to download all the transactions at once and the large number of elements that must be added to the DOM.

Since no changes have been made to the api or the node, this pr does not solve the first problem. However, paging was implemented as on the block list, and now only 25 transactions are displayed at the same time, which eliminates the second problem. The efficiency in the use of the network remains the same, since the list of transactions is requested to the server only once, regardless of whether the user uses the paging control.

After implementing the necessary changes in the node it will be possible to increase the efficiency of the process even more.