### PR TITLE
Fix unconfirmed txs page

### DIFF
--- a/src/app/services/explorer/explorer.service.ts
+++ b/src/app/services/explorer/explorer.service.ts
@@ -5,6 +5,7 @@ import { Block, Output, parseGetAddressTransaction, parseGetBlocksBlock, parseGe
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/observable/of';
 
 @Injectable()
 export class ExplorerService {
@@ -60,9 +61,13 @@ export class ExplorerService {
 
         let parsedResponse = response.map(rawTx => parseGetUnconfirmedTransaction(rawTx));
 
-        return Observable.forkJoin(parsedResponse.map(transaction => {
-          return this.retrieveInputsForTransaction(transaction);
-        }));
+        if (parsedResponse.length > 0) {
+          return Observable.forkJoin(parsedResponse.map(transaction => {
+            return this.retrieveInputsForTransaction(transaction);
+          }));
+        } else {
+          return Observable.of(parsedResponse);
+        }
       })
   }
   


### PR DESCRIPTION
This pr solves an error ( reported in https://github.com/skycoin/skycoin-explorer/issues/154 ) that caused the transaction page to show "loading" infinitely if there were no unconfirmed transactions (if there were, the page worked correctly).