### PR TITLE
Spacing fix

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -44,7 +44,7 @@ h2 {
         display: block;
         float: left;
         color: $gray;
-        width: 110px;
+        width: 130px;
       }
 
       .-link {


### PR DESCRIPTION
Solve this small problem in the address page:
![1_](https://user-images.githubusercontent.com/34079003/38209005-dfb50b3c-3680-11e8-9e48-3858073713bd.png)

With the change, it looks like this:
![2_](https://user-images.githubusercontent.com/34079003/38209022-ed1e0bca-3680-11e8-8ca4-9dc4f64b5db3.png)
