### PR TITLE
Small e2e fix

### DIFF
--- a/e2e/transaction-detail/transaction-detail.e2e-spec.ts
+++ b/e2e/transaction-detail/transaction-detail.e2e-spec.ts
@@ -10,9 +10,9 @@ describe('skycoin-explorer Transaction Page', () => {
     expect(page.getTransactionText()).toEqual('Transaction');
   });
 
-  it('should display 3 Transaction details Rows', () => {
+  it('should display 5 Transaction details Rows', () => {
     page.navigateTo();
-    expect(page.getDetailsRow()).toEqual(3);
+    expect(page.getDetailsRow()).toEqual(5);
   });
 
   it('should show the Transaction Id  and its length should be 64', () => {


### PR DESCRIPTION
https://github.com/skycoin/skycoin-explorer/pull/159 and https://github.com/skycoin/skycoin-explorer/pull/160 added a new row each to the address details table, in the address page. As a result, an e2e test fails. The correction is in this pr because the changes that make the test fail are in 2 prs and not 1....