### PR TITLE
Fix the scroll positioning

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,8 @@ export class AppComponent {
 
     router.events.subscribe((event: RouterEvent) => {
       this.navigationInterceptor(event);
+      if (event instanceof NavigationEnd)
+        window.scrollTo(0, 0);
     });
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterModule, RouteReuseStrategy } from '@angular/router';
 
 import { AppComponent } from './app.component';
 import { FooterComponent } from './components/layout/footer/footer.component';
@@ -21,6 +21,7 @@ import { FormsModule } from '@angular/forms';
 import { RichlistComponent } from 'app/components/pages/richlist/richlist.component';
 import { CopyButtonComponent } from 'app/components/layout/copy-button/copy-button.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { AppReuseStrategy } from 'app/app.reuse-strategy';
 
 
 const ROUTES = [
@@ -91,6 +92,7 @@ const ROUTES = [
   providers: [
     ApiService,
     ExplorerService,
+    {provide: RouteReuseStrategy, useClass: AppReuseStrategy}
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/app.reuse-strategy.ts
+++ b/src/app/app.reuse-strategy.ts
@@ -1,0 +1,29 @@
+import { RouteReuseStrategy, ActivatedRouteSnapshot, DetachedRouteHandle } from "@angular/router";
+
+export class AppReuseStrategy implements RouteReuseStrategy {
+
+  shouldDetach(route: ActivatedRouteSnapshot): boolean {
+    return false;
+  }
+
+  store(route: ActivatedRouteSnapshot, handle: DetachedRouteHandle): void { }
+
+  shouldAttach(route: ActivatedRouteSnapshot): boolean {
+    return false;
+  }
+
+  retrieve(route: ActivatedRouteSnapshot): DetachedRouteHandle {
+    return null;
+  }
+
+  shouldReuseRoute(future: ActivatedRouteSnapshot, curr: ActivatedRouteSnapshot): boolean {
+    //Reuse only the address page. Also only if the navigation is from it and to it.
+    if (curr.routeConfig && curr.routeConfig.path.includes('app/address/') && future.routeConfig && future.routeConfig.path.includes('app/address/')) 
+      return true;
+    else if ((curr.children && curr.children.length > 0 && curr.children[0].routeConfig && curr.children[0].routeConfig.path.includes('app/address/')) &&
+            (future.children && future.children.length > 0 && future.children[0].routeConfig && future.children[0].routeConfig.path.includes('app/address/')))
+      return true;
+    else
+      return false;
+  }
+}

--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -34,9 +34,18 @@ export class AddressDetailComponent implements OnInit {
 
   ngOnInit() {
     this.route.params.switchMap((params: Params) => {
+      //Clear the content if the address, and not just the page, changes
+      if (this.address != params['address']) {
+        this.transactions = undefined;
+        this.balance = undefined;
+      }
+
       this.address = params['address'];
       if (params['page'])
         this.pageIndex = parseInt(params['page'], 10) - 1;
+
+      //Clear the list content.
+      this.pageTransactions = undefined;
 
       if (this.transactions)
         return Observable.of(this.transactions);


### PR DESCRIPTION
Solves https://github.com/skycoin/skycoin-explorer/issues/163

To solve the second point of the issue this pr changes the way the Angular router works. Normally, when navigating to the same URL in which the user is already located, Angular reuses the page component. If the URL is different, the router creates a new component. With this pr the router stops working in that way, now always creates a new component, regardless of whether the URL is the same and only changed the parameters.

However, an exception was placed. The address page continues to work as before. This allows to clean the screen directly in the AddressDetailComponent code and thus avoid reloading the data from the server every time a change is made in the paging, which would be very slow when the addresses have many transactions and would eliminate the main optimization of https://github.com/skycoin/skycoin-explorer/pull/148. In fact, cleaning all the screens in this way would be a more efficient solution, but it would negatively affect the maintainability of the code.