### PR TITLE
Add /balance endpoint

### DIFF
--- a/explorer.go
+++ b/explorer.go
@@ -695,6 +695,23 @@ var apiEndpoints = []APIEndpoint{
 			}
 	]`,
 	},
+	{
+		ExplorerPath:   "/api/balance",
+		SkycoinPath:    "/balance",
+		QueryArgs:      []string{"addrs"},
+		Description:    "Returns the combined balance of a list of comma-separated addresses.",
+		ExampleRequest: "/api/balance?addrs=7cpQ7t3PZZXvjTst8G7Uvs7XH4LeM8fBPD,nu7eSpT6hr5P21uzw7bnbxm83B6ywSjHdq",
+		ExampleResponse: `{
+			"confirmed": {
+					"coins": 70000000,
+					"hours": 28052
+			},
+			"predicted": {
+					"coins": 9000000,
+					"hours": 8385
+			}
+		}`,
+	},
 }
 
 var docEndpoint APIEndpoint = APIEndpoint{


### PR DESCRIPTION
Adds the /balance endpoint, which can be useful for the address screen. At this moment the balance of the addresses is calculated with the api endpoint which returns all the unspent outputs, the /balance endpoint returns much less data, so using it would be more efficient.