### PR TITLE
Small fix for CopyButtonComponent

### DIFF
--- a/src/app/components/layout/copy-button/copy-button.component.ts
+++ b/src/app/components/layout/copy-button/copy-button.component.ts
@@ -45,8 +45,8 @@ export class CopyButtonComponent {
   private static showAnimName = 'show';
   private static hideAnimName = 'hide';
 
-  private animState = CopyButtonComponent.hideAnimName;
-  private showLabel = false;
+  animState = CopyButtonComponent.hideAnimName;
+  showLabel = false;
   @Input() text: string;
   @HostBinding('attr.class') cssClass = 'copy-button'; 
 
@@ -72,7 +72,7 @@ export class CopyButtonComponent {
     this.showLabel = true;
   }
 
-  private animationDone(event: AnimationEvent) {
+  animationDone(event: AnimationEvent) {
     if (event.toState == CopyButtonComponent.showAnimName)
       this.animState = CopyButtonComponent.hideAnimName;
     else


### PR DESCRIPTION
The copy button was preventing production builds to be correctly made (using `make build-ng`), dev buils had no problems (the ones made with `ng build`). This pr fixes the problem.