### PR TITLE
Optimized address balance

### DIFF
--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -228,6 +228,16 @@ export class GetBlockchainMetadataResponseHead {
   seq: number;
 }
 
+export class GetBalanceResponse {
+  confirmed: GetBalanceResponseElement;
+  predicted: GetBalanceResponseElement;
+}
+
+class GetBalanceResponseElement {
+  coins: number;
+  hours: number;
+}
+
 export class GetCurrentBalanceResponse {
   head_outputs: GetCurrentBalanceResponseOutput[];
 }

--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -69,9 +69,9 @@ export class AddressDetailComponent implements OnInit {
         }
       }
     );
-
-    this.route.params.switchMap((params: Params) => this.api.getCurrentBalance(params['address']))
-      .subscribe(response => this.balance = response.head_outputs.reduce((a, b) => a + parseFloat(b.coins), 0));
+    
+    this.route.params.switchMap((params: Params) => this.api.getBalance(params['address']))
+      .subscribe(response => this.balance = response.confirmed.coins / 1000000);
   }
 
   updateTransactions() {

--- a/src/app/services/api/api.service.ts
+++ b/src/app/services/api/api.service.ts
@@ -3,7 +3,7 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { CoinSupply } from '../../components/pages/blocks/block';
 import { Blockchain, GetBlocksResponse, GetBlockchainMetadataResponse, GetUnconfirmedTransaction, GetUxoutResponse, GetAddressResponseTransaction,
-    GetCurrentBalanceResponse, GetBlocksResponseBlock, RichlistEntry } from '../../app.datatypes';
+    GetCurrentBalanceResponse, GetBlocksResponseBlock, RichlistEntry, GetBalanceResponse } from '../../app.datatypes';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
@@ -46,6 +46,10 @@ export class ApiService {
 
   getCurrentBalance(address: string): Observable<GetCurrentBalanceResponse> {
     return this.get('currentBalance', { addrs: address })
+  }
+
+  getBalance(address: string): Observable<GetBalanceResponse> {
+    return this.get('balance', { addrs: address })
   }
 
   getTransaction(transactionId:string): Observable<any> {


### PR DESCRIPTION
This pr uses the `/balance` endpoint, added in https://github.com/skycoin/skycoin-explorer/pull/168 , to show the balance in the address page, which is more efficient than the method that was being used ( to get all the unspent outputs and add the coins).