### PR TITLE
Display block and transaction size

### DIFF
--- a/e2e/address-detail/address-detail.e2e-spec.ts
+++ b/e2e/address-detail/address-detail.e2e-spec.ts
@@ -12,9 +12,9 @@ describe('skycoin-explorer Address Page', () => {
     expect(address).toBeGreaterThan(26);
   });
 
-  it('should show the Address Info row and its length should be 3', () => {
+  it('should show the Address Info row and its length should be 5', () => {
     page.navigateTo();
-    expect(page.getAddressInfo()).toEqual(3);
+    expect(page.getAddressInfo()).toEqual(5);
   });
 
   it('should show the Transactions Rows and its length should be more than 0', () => {

--- a/e2e/block-details/block-details.e2e-spec.ts
+++ b/e2e/block-details/block-details.e2e-spec.ts
@@ -10,9 +10,9 @@ describe('skycoin-explorer Block Details Page', () => {
     expect(page.getOneBlockDetailsText()).toEqual('Block Details');
   });
 
-  it('should display 5 block details rows', () => {
+  it('should display 6 block details rows', () => {
     page.navigateTo();
-    expect(page.getDetailsRow()).toEqual(5);
+    expect(page.getDetailsRow()).toEqual(6);
   });
 
   it('should show the details of the Hash and its length should be 64', () => {

--- a/e2e/transaction-detail/transaction-detail.e2e-spec.ts
+++ b/e2e/transaction-detail/transaction-detail.e2e-spec.ts
@@ -10,9 +10,9 @@ describe('skycoin-explorer Transaction Page', () => {
     expect(page.getTransactionText()).toEqual('Transaction');
   });
 
-  it('should display 5 Transaction details Rows', () => {
+  it('should display 4 Transaction details Rows', () => {
     page.navigateTo();
-    expect(page.getDetailsRow()).toEqual(5);
+    expect(page.getDetailsRow()).toEqual(4);
   });
 
   it('should show the Transaction Id  and its length should be 64', () => {

--- a/e2e/unconfirmed-transactions/unconfirmed-transactions.e2e-spec.ts
+++ b/e2e/unconfirmed-transactions/unconfirmed-transactions.e2e-spec.ts
@@ -12,8 +12,8 @@ describe('skycoin-explorer Unconfirmed Transactions Page', () => {
     );
   });
 
-  it('should display 3 Unconfirmed Transactions details', () => {
+  it('should display 4 Unconfirmed Transactions details', () => {
     page.navigateTo();
-    expect(page.getDetailsRow()).toEqual(3);
+    expect(page.getDetailsRow()).toEqual(4);
   });
 });

--- a/explorer.go
+++ b/explorer.go
@@ -313,19 +313,20 @@ var apiEndpoints = []APIEndpoint{
                     {
                         "uxid": "8a941208d3f2d2c4a32438e05645fb64dba3b4b7d83c48d52f51bc1eb9a4117a",
                         "dst": "2GgFvqoyk9RjwVzj8tqfcXVXB4orBwoc9qv",
-                        "coins": "2361",
+                        "coins": "2361.000000",
                         "hours": 1006716
                     },
                     {
                         "uxid": "a70d1f0f488066a327acd0d5ea77b87d62b3b061d3db8361c90194a6520ab29f",
                         "dst": "SeDoYN6SNaTiAZFHwArnFwQmcyz7ZvJm17",
-                        "coins": "51",
+                        "coins": "51.000000",
                         "hours": 2013433
                     }
                 ]
             }
         ]
-    }
+    },
+    "size": 414
 }`,
 	},
 
@@ -376,19 +377,20 @@ var apiEndpoints = []APIEndpoint{
                             {
                                 "uxid": "ce1075dd609622b0c28d4106f58943d7f0cae6baffbe9f048bb5bc5f23706b93",
                                 "dst": "PRXLNyB64cqaiG4pCoFZZ8Tuv7LWYPpa7m",
-                                "coins": "4900",
+                                "coins": "4900.000000",
                                 "hours": 6402335
                             },
                             {
                                 "uxid": "d73cf1f1d04a1d493fe3480a00e48187f9201bb64828fe0c638f17c0c88bb3d9",
                                 "dst": "YPhukwVyLsPGX1FAPQa2ktr5XnSLqyGbr5",
-                                "coins": "5",
+                                "coins": "5.000000",
                                 "hours": 6402335
                             }
                         ]
                     }
                 ]
-            }
+						},
+						"size": 802
         },
         {
             "header": {
@@ -417,19 +419,20 @@ var apiEndpoints = []APIEndpoint{
                             {
                                 "uxid": "c8b8eac053a5640bae40144cbc3dda02746071e3c7d00a4b5dfd06d28f928ec4",
                                 "dst": "PRXLNyB64cqaiG4pCoFZZ8Tuv7LWYPpa7m",
-                                "coins": "2500",
+                                "coins": "2500.000000",
                                 "hours": 800291
                             },
                             {
                                 "uxid": "16dd81af869743599fe60108c22d7ee1fcbf1a7f460fffd3a015fbb3f721c36d",
                                 "dst": "YPhukwVyLsPGX1FAPQa2ktr5XnSLqyGbr5",
-                                "coins": "2400",
+                                "coins": "2400.000000",
                                 "hours": 800291
                             }
                         ]
                     }
                 ]
-            }
+						},
+						"size": 220
         }
     ]
 }`,

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -21,6 +21,7 @@ export class Block {
   parent_hash: string;
   timestamp: number;
   transactions: Transaction[];
+  size: number;
 }
 
 export class Blockchain {
@@ -43,6 +44,7 @@ export class Transaction {
   timestamp: number;
   balance: number;
   addressBalance: number;
+  length: number;
 }
 
 export class Wallet {
@@ -70,6 +72,7 @@ export class GetAddressResponseTransaction {
   status: any;
   timestamp: number;
   txid: string;
+  length: number;
 }
 
 export function parseGetAddressTransaction(raw: GetAddressResponseTransaction, address: string): Transaction {
@@ -95,6 +98,7 @@ export function parseGetAddressTransaction(raw: GetAddressResponseTransaction, a
     status: raw.status.confirmed,
     balance: balance,
     addressBalance: null,
+    length: raw.length,
   }
 }
 
@@ -138,6 +142,7 @@ export class GetUnconfirmedTransaction {
 
 export class GetUnconfirmedTransactionBody {
   txid: string;
+  length: number;
   inputs: string[];
   outputs: GetAddressResponseTransactionOutput[];
 }
@@ -152,6 +157,7 @@ export function parseGetUnconfirmedTransaction(raw: GetUnconfirmedTransaction): 
     timestamp: new Date(raw.received).getTime(),
     balance: null,
     addressBalance: null,
+    length: raw.transaction.length,
   }
 }
 
@@ -162,6 +168,7 @@ export class GetBlocksResponse {
 export class GetBlocksResponseBlock {
   body: GetBlocksResponseBlockBody;
   header: GetBlocksResponseBlockHeader;
+  size: number;
 }
 
 export function parseGetBlocksBlock(block: GetBlocksResponseBlock): Block {
@@ -170,7 +177,8 @@ export function parseGetBlocksBlock(block: GetBlocksResponseBlock): Block {
     hash: block.header.block_hash,
     parent_hash: block.header.previous_block_hash,
     timestamp: block.header.timestamp,
-    transactions: block.body.txns.map(transaction => parseGetBlocksTransaction(transaction))
+    transactions: block.body.txns.map(transaction => parseGetBlocksTransaction(transaction)),
+    size: block.size,
   }
 }
 
@@ -184,6 +192,7 @@ function parseGetBlocksTransaction(transaction: GetBlocksResponseBlockBodyTransa
     status: null,
     balance: null,
     addressBalance: null,
+    length: transaction.length,
   }
 }
 
@@ -202,6 +211,7 @@ class GetBlocksResponseBlockBody {
 
 class GetBlocksResponseBlockBodyTransaction {
   txid: string;
+  length: number;
   inputs: string[];
   outputs: GetBlocksResponseBlockBodyTransactionOutput[];
 }
@@ -270,6 +280,7 @@ export function parseGetTransaction(raw: GetTransactionResponse): Transaction {
     timestamp: raw.txn.timestamp,
     balance: null,
     addressBalance: null,
+    length: raw.txn.length,
   }
 }
 
@@ -308,6 +319,7 @@ class GetTransactionTransaction {
   outputs: GetTransactionOutput[];
   timestamp: number;
   txid: string;
+  length: number;
 }
 
 export class GetUxoutResponse {

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -3,6 +3,7 @@
   <div class="element-details">
     <div class="-row"><span>Height</span><br class="-xs-only" /><div> {{ block ? block.id : loadingMsg }} </div></div>
     <div class="-row"><span>Timestamp</span><br class="-xs-only" /><div> {{ block ? ((block.timestamp * 1000) | date: 'short') : loadingMsg }} </div></div>
+    <div class="-row"><span>Size</span><br class="-xs-only" /><div> {{ block ? (block.size | number) + ' bytes' : loadingMsg }} </div></div>
     <div class="-row"><span>Hash</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + block.id" class="-link" *ngIf="block">{{ block.hash }}</a> <copy-button [text]="block.hash" *ngIf="block"></copy-button> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>Parent Hash</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + (block.id-1)" class="-link" *ngIf="block && block.parent_hash">{{ block.parent_hash }}</a> <copy-button [text]="block.parent_hash" *ngIf="block && block.parent_hash"></copy-button> <span *ngIf="block && !block.parent_hash">Without parent block</span> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>Total Amount</span><br class="-xs-only" /><div> {{ block ? ((block.transactions | transactionsValue) | number:'1.0-6') + ' SKY' : loadingMsg }} </div></div>

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -3,6 +3,7 @@
   <div class="element-details">
     <div class="-row"><span>Status</span><br class="-xs-only" /><div> {{ transaction ? (transaction.status ? 'Confirmed' : 'Unconfirmed') : loadingMsg }} </div></div>
     <div class="-row"><span>Timestamp</span><br class="-xs-only" /><div> {{ transaction ? (transaction.timestamp * 1000 | date: 'short') : loadingMsg }} </div></div>
+    <div class="-row"><span>Size</span><br class="-xs-only" /><div> {{ transaction ? (transaction.length | number) + ' bytes' : loadingMsg }} </div></div>
     <div class="-row"><span>Block</span><br class="-xs-only" /><div> {{ transaction ? transaction.block : loadingMsg }} </div></div>
   </div>
 </div>

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
@@ -2,6 +2,7 @@
   <h2>Unconfirmed Transactions</h2>
   <div class="element-details">
     <div class="-row"><span>Quantity</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? transactions.length : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
+    <div class="-row"><span>Total Size</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (totalSize | number) + ' bytes' : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
     <div class="-row"><span>Newest</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (mostRecent | date: 'short') : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
     <div class="-row"><span>Oldest</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (leastRecent | date: 'short') : 'Currently there are no unconfirmed transactions.') : loadingMsg }} </div></div>
   </div>

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.ts
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.ts
@@ -15,6 +15,7 @@ export class UnconfirmedTransactionsComponent implements OnInit {
   transactions: Transaction[];
   leastRecent: number;
   mostRecent: number;
+  totalSize: number;
   loadingMsg = "Loading...";
   longErrorMsg: string;
 
@@ -30,6 +31,7 @@ export class UnconfirmedTransactionsComponent implements OnInit {
         let orderedList = transactions.sort((a, b) => b.timestamp - a.timestamp);
         this.mostRecent = orderedList[0].timestamp;
         this.leastRecent = orderedList[orderedList.length-1].timestamp;
+        this.totalSize = orderedList.map(tx => tx.length).reduce((sum, current) => sum + current);
       }
     }, error => {
       this.loadingMsg = "Loading error";

--- a/src/app/services/api/api.service.ts
+++ b/src/app/services/api/api.service.ts
@@ -3,7 +3,7 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { CoinSupply } from '../../components/pages/blocks/block';
 import { Blockchain, GetBlocksResponse, GetBlockchainMetadataResponse, GetUnconfirmedTransaction, GetUxoutResponse, GetAddressResponseTransaction,
-    GetCurrentBalanceResponse, GetBlocksResponseBlock, RichlistEntry } from '../../app.datatypes';
+    GetCurrentBalanceResponse, GetBlocksResponseBlock, RichlistEntry, GetTransactionResponse } from '../../app.datatypes';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
@@ -48,7 +48,7 @@ export class ApiService {
     return this.get('currentBalance', { addrs: address })
   }
 
-  getTransaction(transactionId:string): Observable<any> {
+  getTransaction(transactionId:string): Observable<GetTransactionResponse> {
     return this.get('transaction', { txid: transactionId });
   }
 


### PR DESCRIPTION
Solves https://github.com/skycoin/skycoin-explorer/issues/135

Change in the block details page:
![new_block](https://user-images.githubusercontent.com/34079003/39026350-9a53da1c-441a-11e8-9134-3428906c27de.png)

Change in the transaction page:
![new_tx](https://user-images.githubusercontent.com/34079003/39026357-ac0e7ece-441a-11e8-9af5-c0616d76c20c.png)

Change in the unconfirmed transactions page:
![new_un_tx](https://user-images.githubusercontent.com/34079003/39026373-ba5a4558-441a-11e8-9b29-11de095a4a88.png)

This pr also includes fixes for the e2e tests.