### PR TITLE
Fix copy button style

### DIFF
--- a/src/app/components/layout/copy-button/copy-button.component.scss
+++ b/src/app/components/layout/copy-button/copy-button.component.scss
@@ -9,6 +9,7 @@
   color: rgb(223, 223, 223);
   cursor: pointer;
   user-select: none;
+  font-weight: 300;
 }
 
 .icon:hover {


### PR DESCRIPTION
After updating Font Awesome, some copy buttons changed their appearance from this:
![cp1](https://user-images.githubusercontent.com/34079003/39343067-ec9ff196-49a8-11e8-9138-a4c9e5aa5e73.png)
To this:
![cp2](https://user-images.githubusercontent.com/34079003/39343070-f2511412-49a8-11e8-99bd-992992c48818.png)
This pr makes all copy buttons look like the first image, to maintain consistency.