### PR TITLE
Bip21 compatible qr codes

### DIFF
--- a/src/app/components/layout/qr-code/qr-code.component.ts
+++ b/src/app/components/layout/qr-code/qr-code.component.ts
@@ -19,7 +19,7 @@ export class QrCodeComponent implements OnInit {
 
   ngOnInit() {
     new QRCode(this.qr.nativeElement, {
-      text: this.string,
+      text: `skycoin:${this.string}`,
       width: this.size,
       height: this.size,
       colorDark: this.colordark,


### PR DESCRIPTION
This pr makes the qr codes compatible with Bip 21, the format used by the wallet from this pr: https://github.com/skycoin/skycoin/pull/1185