### PR TITLE
Configurable qr codes

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -1,6 +1,10 @@
 # Customizing the explorer
 
-The explorer is designed in such a way that it is possible to make simple customizations to the ui appearance with relative ease.
+The explorer is designed in such a way that it is possible to make simple customizations with relative ease.
+
+## QR codes
+
+To simplify copying addresses with mobile devices, the explorer shows qr codes. The qr codes contain the addresses prefixed with the name of the coin, in this way: `skycoin:abcd...` (More information in this link: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki). If needed, the `skycoin:` prefix can be changed by modifying the value of `QrConfig.prefix`, inside [app.config.ts](src/app/app.config.ts).
 
 ## Colors and general appearance
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Run linters:
 make lint
 ```
 
-### UI Customization
+### Customization
 
 [CUSTOMIZATION.md](CUSTOMIZATION.md)
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,3 +1,7 @@
+export const QrConfig = {
+  prefix: "skycoin:",
+};
+
 export const HeaderConfig = {
   useGenericHeader: false,
   genericHeaderUrl: "https://www.skycoin.net/",

--- a/src/app/components/layout/qr-code/qr-code.component.ts
+++ b/src/app/components/layout/qr-code/qr-code.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { QrConfig } from 'app/app.config';
 
 declare var QRCode: any;
 
@@ -19,7 +20,7 @@ export class QrCodeComponent implements OnInit {
 
   ngOnInit() {
     new QRCode(this.qr.nativeElement, {
-      text: `skycoin:${this.string}`,
+      text: QrConfig.prefix + this.string,
       width: this.size,
       height: this.size,
       colorDark: this.colordark,


### PR DESCRIPTION
Improvement suggested  in https://github.com/skycoin/skycoin-explorer/pull/186#issuecomment-385856522

With this pr it is now possible to configure the prefix of the addresses in the qr codes. This makes it easier to configure the use of BIP21 while customizing the explorer.

This pr also includes the corresponding indications in CUSTOMIZATION.md, so it would be good if the wording is reviewed.