### PR TITLE
[WIP] Snyk update

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.10.2
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:debug:20170905':
+    - karma > socket.io > socket.io-adapter > socket.io-parser > debug:
+        patched: '2018-04-18T04:53:49.215Z'
+  'npm:ms:20170412':
+    - karma > socket.io > socket.io-adapter > socket.io-parser > debug > ms:
+patched: '2018-04-18T04:53:49.215Z'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e -s false"
+    "e2e": "ng e2e -s false",
+    "snyk-protect": "snyk protect",
+    "prepare": "npm run snyk-protect"
   },
   "private": true,
   "dependencies": {
@@ -28,7 +30,8 @@
     "disable-scroll": "^0.4.0",
     "moment": "^2.21.0",
     "rxjs": "^5.5.2",
-    "zone.js": "^0.8.14"
+    "zone.js": "^0.8.14",
+    "snyk": "^1.71.0"
   },
   "devDependencies": {
     "@angular/cli": "^1.7.3",
@@ -38,9 +41,9 @@
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "^6.0.101",
     "codelyzer": "~4.0.1",
-    "jasmine-core": "~2.6.2",
+    "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.1.0",
-    "karma": "~1.7.0",
+    "karma": "~2.0.0",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^1.4.2",
@@ -50,5 +53,6 @@
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",
     "typescript": "~2.4.2"
-  }
+  },
+  "snyk": true
 }


### PR DESCRIPTION
Similar to https://github.com/skycoin/skycoin-explorer/pull/175, but keeps jasmine-core version 2 to avoid problems. The explorer and the e2e tests continue to work after updating the packages.