### PR TITLE
Add next/prev block buttons to block page

### DIFF
--- a/e2e/block-details/block-details.e2e-spec.ts
+++ b/e2e/block-details/block-details.e2e-spec.ts
@@ -56,6 +56,26 @@ describe('skycoin-explorer Block Details Page', () => {
     expect(generalFunctions.getTransactionInputsAndOutputsTotalCoins()).toBe(1999980);
   });
 
+  it('should display the "Previous block" button', () => {
+    expect(page.getNavigationButtonText(0)).toBe("Previous block");
+  });
+
+  it('should display the "Next block" button', () => {
+    expect(page.getNavigationButtonText(1)).toBe("Next block");
+  });
+
+  it('should navigate to the previous block using the nav button', () => {
+    page.clickNavigationButton(0).then(() => {
+      expect(page.getBlockHash()).toEqual("415e47348a1e642cb2e31d00ee500747d3aed0336aabfff7d783ed21465251c7");
+    });
+  });
+
+  it('should navigate to the next block using the nav button', () => {
+    page.clickNavigationButton(1).then(() => {
+      expect(page.getBlockHash()).toEqual("114fe60587a158428a47e0f9571d764f495912c299aa4e67fc88004cf21b0c24");
+    });
+  });
+
   it('should show the error message', () => {
     generalFunctions.navigateTo('/app/block/-1');
     expect(generalFunctions.getErrorMessage()).toBeDefined();

--- a/e2e/block-details/block-details.po.ts
+++ b/e2e/block-details/block-details.po.ts
@@ -39,4 +39,20 @@ export class BlockDetailsPage {
       .getText()
       .then(text => Number(text.split(' ')[0].replace(new RegExp(',', 'g'), '')));
   }
+
+  getNavigationButtonText(index: number) {
+    return element
+      .all(by.css('.header-container > div > a'))
+      .get(index)
+      .element(by.css('.-not-xs'))
+      .getAttribute('textContent');
+  }
+
+  clickNavigationButton(index: number) {
+    return element
+      .all(by.css('.header-container > div > a'))
+      .get(index)
+      .element(by.css('.-not-xs'))
+      .click();
+  }
 }

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -1,5 +1,18 @@
 <div class="element-details-wrapper">
-  <h2>{{ 'blockDetails.title' | translate }}</h2>
+  <div>
+    <div class="header-container">
+      <h2>{{ 'blockDetails.title' | translate }}</h2>
+      <div class="nav-button-container" *ngIf="blockCount && block != undefined">
+        <a [routerLink]="'/app/block/' + (block.id - 1)" class="nav-button" *ngIf="block.id > 0">
+          <span class="font-awesome">&#xf104;</span> <span class="-not-xs">{{ 'blockDetails.previous' | translate }}</span>
+        </a>
+        <span *ngIf="block.id > 0 && block.id < blockCount" class="-not-xs">&nbsp;</span>
+        <a [routerLink]="'/app/block/' + (block.id + 1)" class="nav-button" *ngIf="block.id < blockCount">
+          <span class="-not-xs">{{ 'blockDetails.next' | translate }}</span> <span class="font-awesome">&#xf105;</span>
+        </a>
+      </div>
+    </div>
+  </div>
   <div class="element-details">
     <div class="-row"><span>{{ 'blockDetails.height' | translate }}</span><br class="-xs-only" /><div> {{ block ? block.id : loadingMsg }} </div></div>
     <div class="-row"><span>{{ 'blockDetails.timestamp' | translate }}</span><br class="-xs-only" /><div> {{ block ? (block.timestamp | explorerDate) : loadingMsg }} </div></div>

--- a/src/app/components/pages/block-details/block-details.component.scss
+++ b/src/app/components/pages/block-details/block-details.component.scss
@@ -1,0 +1,40 @@
+@import '../../../../assets/scss/_variables.scss';
+
+h2 {
+  flex-grow: 1;
+}
+
+.header-container {
+
+  display: flex;
+  flex-wrap: wrap;
+
+  .nav-button-container {
+
+    align-self: center;
+    height: 36px;
+
+    a {
+      color: $primary;
+      text-decoration: none;
+      text-transform: uppercase;
+    }
+
+    .nav-button {
+      display: inline-block;
+      line-height: 36px;
+      border: $primary solid 1px;
+      padding: 0px 15px;
+      border-radius: 100px;
+
+      &:hover {
+        background-color: $col-normal-separator;
+      }
+    }
+
+    .font-awesome {
+      font-family: 'Font Awesome 5 Free';
+      font-weight: 900;
+    }
+  }
+}

--- a/src/app/components/pages/block-details/block-details.component.ts
+++ b/src/app/components/pages/block-details/block-details.component.ts
@@ -5,6 +5,7 @@ import { Block, Output, Transaction } from '../../../app.datatypes';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/switchMap';
 import { TranslateService } from '@ngx-translate/core';
+import { ApiService } from 'app/services/api/api.service';
 
 @Component({
   selector: 'app-block-details',
@@ -15,12 +16,14 @@ export class BlockDetailsComponent implements OnInit {
   block: Block;
   loadingMsg = "";
   longErrorMsg: string;
+  blockCount:number;
 
   constructor(
     private explorer: ExplorerService,
     private route: ActivatedRoute,
     private router: Router,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private api: ApiService,
   ) {
     translate.get('general.loadingMsg').subscribe((res: string) => {
       this.loadingMsg = res;
@@ -28,6 +31,9 @@ export class BlockDetailsComponent implements OnInit {
   }
 
   ngOnInit() {
+
+    this.api.getBlockchainMetadata().first().subscribe(blockchain => this.blockCount = blockchain.blocks);
+
     this.route.params.filter(params => +params['id'] !== null)
       .switchMap((params: Params) => this.explorer.getBlock(+params['id']))
       .subscribe((block: Block) => {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -34,6 +34,8 @@
   },
   "blockDetails": {
     "title": "Block Details",
+    "next": "Next block",
+    "previous": "Previous block",
     "height": "Height",
     "timestamp": "Timestamp",
     "size": "Size",


### PR DESCRIPTION
Fixes #201 

This pr adds the "Previous block" and "Next block" buttons to the block details page and e2e test for them. The buttons are similar to those on the website, although not exactly the same. They look like this:

Big screen:
![bt3](https://user-images.githubusercontent.com/34079003/40952586-d0a46502-6849-11e8-9c1d-9cef9695c6ac.png)

Small screen:
![tx4](https://user-images.githubusercontent.com/34079003/40952591-d4a37cec-6849-11e8-90e2-7cc5742d68b3.png)

During the implementation I created a similar but more subtle desing. Personally I like it more, but it is not so consistent with the design of the website. It looks like this:

Big screen:
![bt1](https://user-images.githubusercontent.com/34079003/40952598-daf7e48e-6849-11e8-8ad9-af774ad199ed.png)

Small screen:
![bt2](https://user-images.githubusercontent.com/34079003/40952603-de316148-6849-11e8-9d2b-73171fa80359.png)

If you prefer the softer design, I can make the change without much trouble.