### PR TITLE
Link to block page from transaction page

### DIFF
--- a/e2e/transaction-detail/transaction-detail.po.ts
+++ b/e2e/transaction-detail/transaction-detail.po.ts
@@ -14,7 +14,7 @@ export class TransactionDetailPage {
   }
 
   getBlockNumber() {
-    return element(by.css('.element-details > div:nth-of-type(4) > div'))
+    return element(by.css('.element-details > div:nth-of-type(4) > div > a'))
       .getText()
       .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
   }

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -4,7 +4,7 @@
     <div class="-row"><span>{{ 'transactionDetail.status' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? (transaction.status ? ('transactionDetail.confirmed' | translate) : ('transactionDetail.unconfirmed' | translate)) : loadingMsg }} </div></div>
     <div class="-row"><span>{{ 'transactionDetail.timestamp' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? (transaction.timestamp | explorerDate) : loadingMsg }} </div></div>
     <div class="-row"><span>{{ 'transactionDetail.size' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? (transaction.length | number) + ' bytes' : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'transactionDetail.block' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? transaction.block : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'transactionDetail.block' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + transaction.block" class="-link" *ngIf="transaction">{{ transaction.block }}</a> <copy-button [text]="transaction.block" *ngIf="transaction"></copy-button> <span *ngIf="!transaction">{{ loadingMsg }}</span> </div></div>
   </div>
 </div>
 


### PR DESCRIPTION
Fixes #204 

- Now the block number works as a link.
![link](https://user-images.githubusercontent.com/34079003/41193324-7db35f1e-6bd8-11e8-823c-7aaa7798a077.png)