### PR TITLE
Design improvements

### DIFF
--- a/e2e/address-detail/address-detail.po.ts
+++ b/e2e/address-detail/address-detail.po.ts
@@ -20,13 +20,13 @@ export class AddressDetailPage {
   getTotalReceived() {
     return element(by.css('.element-details > div:nth-of-type(3) > div'))
       .getText()
-      .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
+      .then(text => Number(text.split(' ')[0].replace(new RegExp(',', 'g'), '')));
   }
 
   getCurrentBalance() {
     return element(by.css('.element-details > div:nth-of-type(3) > div'))
       .getText()
-      .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
+      .then(text => Number(text.split(' ')[0].replace(new RegExp(',', 'g'), '')));
   }
 
   getFinalBalance(transsactionIndex: number) {

--- a/e2e/blocks/blocks.po.ts
+++ b/e2e/blocks/blocks.po.ts
@@ -55,17 +55,17 @@ export class BlocksPage {
   }
 
   getBlockNumber(row: number) {
-    return this.getTableCellValue(row, 2)
+    return this.getTableCellValue(row, 4)
       .then(text => Number(text));
   }
 
   getTransactionCount(row: number) {
-    return this.getTableCellValue(row, 3)
+    return this.getTableCellValue(row, 5)
       .then(text => Number(text));
   }
 
   getBlockHashLength(row: number) {
-    return this.getTableCellValue(row, 4)
+    return this.getTableCellValue(row, 6)
       .then(text => text.length);
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,8 @@ import { GenericHeaderComponent } from 'app/components/layout/generic-header/gen
 import { GenericFooterComponent } from 'app/components/layout/generic-footer/generic-footer.component';
 import { ExplorerDatePipe } from 'app/pipes/explorer-date.pipe';
 import { DatePipe } from '@angular/common';
+import { CoinsFormatterComponent } from 'app/components/layout/coins-formatter/coins-formatter.component';
+import { DateFormatterComponent } from 'app/components/layout/date-formatter/date-formatter.component';
 
 
 const ROUTES = [
@@ -96,6 +98,8 @@ const ROUTES = [
     UnspentOutputsComponent,
     CopyButtonComponent,
     ExplorerDatePipe,
+    CoinsFormatterComponent,
+    DateFormatterComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/layout/coins-formatter/coins-formatter.component.html
+++ b/src/app/components/layout/coins-formatter/coins-formatter.component.html
@@ -1,0 +1,1 @@
+<span *ngIf="integerPart != undefined">{{integerPart | number:'1.0-0'}}</span><span [class]="'decimal-part' + ' ' + (whiteText ? '-white' : '-gray')" *ngIf="decimalPart">.{{decimalPart}}</span>

--- a/src/app/components/layout/coins-formatter/coins-formatter.component.scss
+++ b/src/app/components/layout/coins-formatter/coins-formatter.component.scss
@@ -1,0 +1,9 @@
+@import '../../../../assets/scss/_variables.scss';
+
+.decimal-part {
+  font-size: 12px;
+}
+
+.-white {
+  color: #f7f7f7;
+}

--- a/src/app/components/layout/coins-formatter/coins-formatter.component.spec.ts
+++ b/src/app/components/layout/coins-formatter/coins-formatter.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { CoinsFormatterComponent } from 'app/components/layout/coins-formatter/coins-formatter.component';
+
+describe('GenericHeaderComponent', () => {
+  let component: CoinsFormatterComponent;
+  let fixture: ComponentFixture<CoinsFormatterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CoinsFormatterComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CoinsFormatterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/layout/coins-formatter/coins-formatter.component.ts
+++ b/src/app/components/layout/coins-formatter/coins-formatter.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'coins-formatter',
+  templateUrl: './coins-formatter.component.html',
+  styleUrls: ['./coins-formatter.component.scss']
+})
+export class CoinsFormatterComponent {
+  
+  integerPart: number = undefined;
+  decimalPart: string;
+
+  @Input()
+  set amount(value: number | string) {
+
+    if (value == undefined || value == null) return;
+
+    const number = typeof value == "number" ? value : Number((value as string).replace(',', ''));
+
+    this.integerPart = Math.trunc(number);
+
+    const decimal = Math.abs(number - this.integerPart);
+    if (decimal > 0) this.decimalPart = (Number(decimal.toFixed(6)) + '').split('.')[1];
+  }
+
+  @Input()
+  whiteText = false;
+  
+  constructor() { }
+}

--- a/src/app/components/layout/date-formatter/date-formatter.component.html
+++ b/src/app/components/layout/date-formatter/date-formatter.component.html
@@ -1,0 +1,2 @@
+<span *ngIf="date">{{date * dateMultiplier | date:'yyyy-MM-dd'}}</span>
+<span class="time -gray" *ngIf="date">{{date * dateMultiplier | date:'hh:mm:ss'}}</span>

--- a/src/app/components/layout/date-formatter/date-formatter.component.scss
+++ b/src/app/components/layout/date-formatter/date-formatter.component.scss
@@ -1,0 +1,5 @@
+@import '../../../../assets/scss/_variables.scss';
+
+.time {
+  display: inline-block;
+}

--- a/src/app/components/layout/date-formatter/date-formatter.component.spec.ts
+++ b/src/app/components/layout/date-formatter/date-formatter.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DateFormatterComponent } from 'app/components/layout/date-formatter/date-formatter.component';
+
+describe('GenericHeaderComponent', () => {
+  let component: DateFormatterComponent;
+  let fixture: ComponentFixture<DateFormatterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DateFormatterComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DateFormatterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/layout/date-formatter/date-formatter.component.ts
+++ b/src/app/components/layout/date-formatter/date-formatter.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'date-formatter',
+  templateUrl: './date-formatter.component.html',
+  styleUrls: ['./date-formatter.component.scss']
+})
+export class DateFormatterComponent {
+  @Input()date;
+
+  @Input()dateMultiplier = 1000;
+  
+  constructor() { }
+}

--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -7,8 +7,8 @@
       <span>{{ 'general.address' | translate }}</span><br class="-xs-only" /> <span>{{ address ? address : loadingMsg }}</span>
     </div>
     <div class="-row -tx-number"><span>{{ 'addressDetail.txsNumber' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? transactions.length : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'addressDetail.totalReceived' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? ( totalReceived | number:'1.0-6') : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'addressDetail.currentBalance' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? ( balance | number:'1.0-6') : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'addressDetail.totalReceived' | translate }}</span><br class="-xs-only" /><div> <coins-formatter *ngIf="transactions" [amount]="totalReceived | number:'1.0-6'"></coins-formatter> <span *ngIf="transactions">{{'general.coinIdentifier' | translate}}</span> <span *ngIf="!transactions">{{loadingMsg}}</span> </div></div>
+    <div class="-row"><span>{{ 'addressDetail.currentBalance' | translate }}</span><br class="-xs-only" /><div> <coins-formatter *ngIf="transactions" [amount]="balance | number:'1.0-6'"></coins-formatter> <span *ngIf="transactions">{{'general.coinIdentifier' | translate}}</span> <span *ngIf="!transactions">{{loadingMsg}}</span> </div></div>
     <div class="-row"><span>{{ 'addressDetail.tools' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/unspent/' + address" class="-link" *ngIf="address">{{ 'addressDetail.unspentOutputs' | translate }}</a> <span *ngIf="!address">{{ loadingMsg }}</span> </div></div>
   </div>
 </div>
@@ -34,11 +34,11 @@
           <div class="-address"><a [routerLink]="'/app/transaction/' + transaction.id">{{ transaction.id }}</a><copy-button [text]="transaction.id"></copy-button></div>
           <br class="-xs-sm-only" />
           <div class="-label" [ngClass]="{'-red' : transaction.balance < 0, '-green' : transaction.balance >= 0}">
-            {{ (transaction.balance<0?"":"+")+(transaction.balance | number:'1.0-6') }} {{ 'general.coinIdentifier' | translate }} <ng-container *ngIf="!transaction.status">({{ 'txBoxes.pending' | translate }})</ng-container>
+            {{ (transaction.balance<0?"":"+") }}<coins-formatter [amount]="transaction.balance | number:'1.0-6'" [whiteText]="true"></coins-formatter> {{ 'general.coinIdentifier' | translate }} <ng-container *ngIf="!transaction.status">({{ 'txBoxes.pending' | translate }})</ng-container>
           </div>
         </div>
       </div>
-      <div class="col-md-2 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'txBoxes.date' | translate }}:<br/></span>{{ transaction ? (transaction.timestamp | explorerDate) : loadingMsg }}</div></div>
+      <div class="col-md-2 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'txBoxes.date' | translate }}:<br/></span><date-formatter *ngIf="transaction" [date]="transaction.timestamp"></date-formatter></div></div>
     </div>
   </div>
 
@@ -54,21 +54,21 @@
         <div class="-header -xs-only">{{ 'txBoxes.inputs' | translate }}</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
           <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a><copy-button [text]="input.address"></copy-button>
-          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ input.coins | number:'1.0-6' }}</div></div>
+          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="input.coins | number:'1.0-6'"></coins-formatter></div></div>
         </div>
       </div>
       <div class="col-sm-6">
         <div class="-header -xs-only">{{ 'txBoxes.outputs' | translate }}</div>
         <div class="-body" *ngFor="let output of transaction.outputs">
           <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a><copy-button [text]="output.address"></copy-button>
-          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
+          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="output.coins | number:'1.0-6'"></coins-formatter></div></div>
         </div>
       </div>
     </div>
     <div class="row">
       <div class="col-sm-12">
         <div class="-header -xs-only">{{ 'txBoxes.finalBalance' | translate }}</div>
-        <div class="-final-balance"><div><div class="-transparent -not-xs -float-left">{{ 'txBoxes.finalBalance' | translate }}:&nbsp;</div><div class="-transparent -xs-only -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div>{{ transaction.addressBalance | number:'1.0-6' }}</div></div></div>
+        <div class="-final-balance"><div><div class="-transparent -not-xs -float-left">{{ 'txBoxes.finalBalance' | translate }}:&nbsp;</div><div class="-transparent -xs-only -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div><coins-formatter [amount]="transaction.addressBalance | number:'1.0-6'"></coins-formatter> </div></div></div>
       </div>
     </div>
   </div>

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -15,11 +15,11 @@
   </div>
   <div class="element-details">
     <div class="-row"><span>{{ 'blockDetails.height' | translate }}</span><br class="-xs-only" /><div> {{ block ? block.id : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'blockDetails.timestamp' | translate }}</span><br class="-xs-only" /><div> {{ block ? (block.timestamp | explorerDate) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'blockDetails.timestamp' | translate }}</span><br class="-xs-only" /><div> <date-formatter *ngIf="block" [date]="block.timestamp"></date-formatter> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>{{ 'blockDetails.size' | translate }}</span><br class="-xs-only" /><div> {{ block ? (block.size | number) + ' bytes' : loadingMsg }} </div></div>
     <div class="-row"><span>{{ 'blockDetails.hash' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + block.id" class="-link" *ngIf="block">{{ block.hash }}</a> <copy-button [text]="block.hash" *ngIf="block"></copy-button> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>{{ 'blockDetails.parentHash' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/block/' + (block.id-1)" class="-link" *ngIf="block && block.id != 0">{{ block.parent_hash }}</a> <copy-button [text]="block.parent_hash" *ngIf="block && block.id != 0"></copy-button> <span *ngIf="block && block.id == 0">{{ 'blockDetails.withoutParent' | translate }}</span> <span *ngIf="!block">{{ loadingMsg }}</span> </div></div>
-    <div class="-row"><span>{{ 'blockDetails.totalAmount' | translate }}</span><br class="-xs-only" /><div> {{ block ? ((block.transactions | transactionsValue) | number:'1.0-6') + ' ' + ('general.coinIdentifier' | translate) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'blockDetails.totalAmount' | translate }}</span><br class="-xs-only" /><div> <coins-formatter *ngIf="block" [amount]="(block.transactions | transactionsValue) | number:'1.0-6'"></coins-formatter> <span *ngIf="block">{{'general.coinIdentifier' | translate}}</span> <span *ngIf="!block">{{loadingMsg}}</span> </div></div>
   </div>
 </div>
 
@@ -57,14 +57,14 @@
           <div class="-header -xs-only">{{ 'txBoxes.inputs' | translate }}</div>
           <div class="-body" *ngFor="let input of transaction.inputs">
             <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a><copy-button [text]="input.address"></copy-button>
-            <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ input.coins | number:'1.0-6' }}</div></div>
+            <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="input.coins | number:'1.0-6'"></coins-formatter></div></div>
           </div>
         </div>
         <div class="col-sm-6">
           <div class="-header -xs-only">{{ 'txBoxes.outputs' | translate }}</div>
           <div class="-body" *ngFor="let output of transaction.outputs">
             <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a><copy-button [text]="output.address"></copy-button>
-            <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
+            <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="output.coins | number:'1.0-6'"></coins-formatter></div></div>
           </div>
         </div>
       </div>

--- a/src/app/components/pages/blocks/blocks.component.html
+++ b/src/app/components/pages/blocks/blocks.component.html
@@ -4,11 +4,11 @@
     <h2 class="-xs-only">{{ 'blocks.statsTitle' | translate }}</h2>
   </div>
   <div class="col-sm-6 -details">
-    <p><span><span class="-label">{{ 'blocks.blockHeight' | translate }}:</span> <span class="-value">{{ blockCount > 0 ? (blockCount | number : '1.0-0') : loadingMetadataMsg }}</span></span></p>
-    <p><span><span class="-label">{{ 'blocks.currentSupply' | translate }}:</span> <span class="-value">{{ currentSupply ? (currentSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
-    <p><span><span class="-label">{{ 'blocks.totalSupply' | translate }}:</span> <span class="-value">{{ totalSupply ? (totalSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
-    <p><span><span class="-label">{{ 'blocks.currentCoinhourSupply' | translate }}:</span> <span class="-value">{{ currentCoinhourSupply ? (currentCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
-    <p><span><span class="-label">{{ 'blocks.totalCoinhourSupply' | translate }}:</span> <span class="-value">{{ totalCoinhourSupply ? (totalCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">{{ 'blocks.blockHeight' | translate }}:</span><br class="-xs-only"/> <span class="-value">{{ blockCount > 0 ? (blockCount | number : '1.0-0') : loadingMetadataMsg }}</span></span></p>
+    <p><span><span class="-label">{{ 'blocks.currentSupply' | translate }}:</span><br class="-xs-only"/> <span class="-value">{{ currentSupply ? (currentSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">{{ 'blocks.totalSupply' | translate }}:</span><br class="-xs-only"/> <span class="-value">{{ totalSupply ? (totalSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">{{ 'blocks.currentCoinhourSupply' | translate }}:</span><br class="-xs-only"/> <span class="-value">{{ currentCoinhourSupply ? (currentCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
+    <p><span><span class="-label">{{ 'blocks.totalCoinhourSupply' | translate }}:</span><br class="-xs-only"/> <span class="-value">{{ totalCoinhourSupply ? (totalCoinhourSupply | number : '1.0-0') : loadingCoinSupplyMsg }}</span></span></p>
     <p><a routerLink="/app/unconfirmedtransactions" class="-link">{{ 'blocks.unconfirmedTransactions' | translate }}</a></p>
     <p><a routerLink="/app/richlist" class="-link">{{ 'blocks.richList' | translate }}</a></p>
   </div>
@@ -19,7 +19,8 @@
   <div class="-header">
     <div class="row">
       <div class="col-sm-2 col-xs-4"><div>{{ 'blocks.time' | translate }}</div></div>
-      <div class="col-sm-2 col-xs-4"><div>{{ 'blocks.blockNumber' | translate }}</div></div>
+      <div class="col-sm-2 col-xs-4 -not-xs"><div>{{ 'blocks.blockNumber' | translate }}</div></div>
+      <div class="col-sm-2 col-xs-4 -xs-only"><div>{{ 'blocks.blockNumberSmall' | translate }}</div></div>
       <div class="col-sm-2 col-xs-4"><div>{{ 'blocks.transactions' | translate }}</div></div>
       <div class="col-sm-6 -fix-left -not-xs"><div>{{ 'blocks.blockhash' | translate }}</div></div>
     </div>
@@ -32,10 +33,20 @@
       <ng-template #error_msg>{{ longErrorMsg }}</ng-template>
     </div>
   </div>
-  <a class="-row" *ngFor="let block of blocks" [routerLink]="'/app/block/' + block.id">
+  <a class="-row -link" *ngFor="let block of blocks" [routerLink]="'/app/block/' + block.id">
     <div class="row">
-      <div class="col-sm-2 col-xs-4">{{ block.timestamp | explorerDate }}</div>
-      <div class="col-sm-2 col-xs-4 -gray">{{ block.id }}</div>
+      <div class="col-sm-2 col-xs-4">
+        <div class="-not-xs">
+          <date-formatter [date]="block.timestamp"></date-formatter>
+        </div>
+        <div class="-xs-only">
+            <span class="-gray">{{ block.timestamp * 1000 | date:'yyyy' }}</span><br/>
+            <span class="-small-font">{{ (block.timestamp * 1000 | date:'MMM dd').toUpperCase() }}</span><br/>
+            <span class="-small-font">{{ block.timestamp * 1000 | date:'HH:mm' }}</span>
+          </div>
+      </div>
+
+      <div class="col-sm-2 col-xs-4">{{ block.id }}</div>
       <div class="col-sm-2 col-xs-4 -gray">{{ block.transactions.length }}</div>
       <div class="col-sm-6 -fix-left -not-xs">{{ block.hash }}</div>
     </div>

--- a/src/app/components/pages/blocks/blocks.component.scss
+++ b/src/app/components/pages/blocks/blocks.component.scss
@@ -35,5 +35,19 @@
       display: inline-block;
       width: 120px;
     }
+
+    @media (max-width: $max-xs-width) {
+      .-value {
+        margin-top: 5px;
+      }
+    }
   }
+}
+
+.-small-font {
+  font-size: $siz-small-text;
+}
+
+.-link {
+  text-decoration: none;
 }

--- a/src/app/components/pages/richlist/richlist.component.html
+++ b/src/app/components/pages/richlist/richlist.component.html
@@ -20,7 +20,7 @@
     <div class="row">
       <div class="col-sm-1 -not-xs -gray">{{ i+1 }}</div>
       <div class="col-xs-6 col-sm-8">{{ entry.address }}</div>
-      <div class="col-xs-6 col-sm-3">{{ entry.coins | number:'1.0-6' }}</div>
+      <div class="col-xs-6 col-sm-3"><coins-formatter [amount]="entry.coins | number:'1.0-6'"></coins-formatter></div>
     </div>
   </a>
 </div>

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -2,7 +2,7 @@
   <h2>{{ 'transactionDetail.title' | translate }}</h2>
   <div class="element-details">
     <div class="-row"><span>{{ 'transactionDetail.status' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? (transaction.status ? ('transactionDetail.confirmed' | translate) : ('transactionDetail.unconfirmed' | translate)) : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'transactionDetail.timestamp' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? (transaction.timestamp | explorerDate) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'transactionDetail.timestamp' | translate }}</span><br class="-xs-only" /><div> <date-formatter *ngIf="transaction" [date]="transaction.timestamp"></date-formatter> <span *ngIf="!transaction">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>{{ 'transactionDetail.size' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? (transaction.length | number) + ' bytes' : loadingMsg }} </div></div>
     <div class="-row"><span>{{ 'transactionDetail.block' | translate }}</span><br class="-xs-only" /><div> {{ transaction ? transaction.block : loadingMsg }} </div></div>
   </div>
@@ -27,7 +27,7 @@
           <div *ngIf="transaction === undefined">{{ loadingMsg }}</div>
         </div>
       </div>
-      <div class="col-md-4 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'txBoxes.date' | translate }}:<br/></span>{{ transaction ? (transaction.timestamp | explorerDate) : loadingMsg }}</div></div>
+      <div class="col-md-4 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'txBoxes.date' | translate }}:<br/></span><date-formatter *ngIf="transaction" [date]="transaction.timestamp"></date-formatter></div></div>
     </div>
   </div>
 
@@ -43,14 +43,14 @@
         <div class="-header -xs-only">{{ 'txBoxes.inputs' | translate }}</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
           <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a><copy-button [text]="input.address"></copy-button>
-          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ input.coins | number:'1.0-6' }}</div></div>
+          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="input.coins | number:'1.0-6'"></coins-formatter></div></div>
         </div>
       </div>
       <div class="col-sm-6">
         <div class="-header -xs-only">{{ 'txBoxes.outputs' | translate }}</div>
         <div class="-body" *ngFor="let output of transaction.outputs">
           <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a><copy-button [text]="output.address"></copy-button>
-          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
+          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="output.coins | number:'1.0-6'"></coins-formatter></div></div>
         </div>
       </div>
     </div>

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
@@ -3,8 +3,8 @@
   <div class="element-details">
     <div class="-row"><span>{{ 'unconfirmedTx.quantity' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? transactions.length : ('unconfirmedTx.withoutTransactions' | translate)) : loadingMsg }} </div></div>
     <div class="-row"><span>{{ 'unconfirmedTx.size' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (totalSize | number) + ' bytes' : ('unconfirmedTx.withoutTransactions' | translate)) : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'unconfirmedTx.newest' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (mostRecent | explorerDate:false) : ('unconfirmedTx.withoutTransactions' | translate)) : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'unconfirmedTx.oldest' | translate }}</span><br class="-xs-only" /><div> {{ transactions ? (transactions.length > 0 ? (leastRecent | explorerDate:false) : ('unconfirmedTx.withoutTransactions' | translate)) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'unconfirmedTx.newest' | translate }}</span><br class="-xs-only" /><div> <date-formatter *ngIf="transactions && transactions.length > 0" [date]="mostRecent" [dateMultiplier]="1"></date-formatter> <span *ngIf="transactions && transactions.length == 0">{{ 'unconfirmedTx.withoutTransactions' | translate }}</span> <span *ngIf="!transactions">{{ loadingMsg }}</span> </div></div>
+    <div class="-row"><span>{{ 'unconfirmedTx.oldest' | translate }}</span><br class="-xs-only" /><div> <date-formatter *ngIf="transactions && transactions.length > 0" [date]="leastRecent" [dateMultiplier]="1"></date-formatter> <span *ngIf="transactions && transactions.length == 0">{{ 'unconfirmedTx.withoutTransactions' | translate }}</span> <span *ngIf="!transactions">{{ loadingMsg }}</span> </div></div>
   </div>
 </div>
 
@@ -27,7 +27,7 @@
           <div *ngIf="transaction === undefined">{{ loadingMsg }}</div>
         </div>
       </div>
-      <div class="col-md-4 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'txBoxes.firstSeen' | translate }}:<br/></span>{{ transaction ? (transaction.timestamp | explorerDate:false) : loadingMsg }}</div></div>
+      <div class="col-md-4 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'txBoxes.firstSeen' | translate }}:<br/></span><date-formatter *ngIf="transaction" [date]="transaction.timestamp" [dateMultiplier]="1"></date-formatter></div></div>
     </div>
   </div>
 
@@ -43,14 +43,14 @@
         <div class="-header -xs-only">{{ 'txBoxes.inputs' | translate }}</div>
         <div class="-body" *ngFor="let input of transaction.inputs">
           <a class="-link" [routerLink]="'/app/address/' + input.address">{{ input.address }}</a><copy-button [text]="input.address"></copy-button>
-          <div class="-balance"><span class="-transparent">{{ 'general.coins' | translate }}:</span> {{ input.coins | number:'1.0-6' }}</div>
+          <div class="-balance"><span class="-transparent">{{ 'general.coins' | translate }}:</span> <coins-formatter [amount]="input.coins | number:'1.0-6'"></coins-formatter></div>
         </div>
       </div>
       <div class="col-sm-6">
         <div class="-header -xs-only">{{ 'txBoxes.outputs' | translate }}</div>
         <div class="-body" *ngFor="let output of transaction.outputs">
           <a class="-link" [routerLink]="'/app/address/' + output.address">{{ output.address }}</a><copy-button [text]="output.address"></copy-button>
-          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
+          <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="output.coins | number:'1.0-6'"></coins-formatter></div></div>
         </div>
       </div>
     </div>

--- a/src/app/components/pages/unspent-outputs/unspent-outputs.component.html
+++ b/src/app/components/pages/unspent-outputs/unspent-outputs.component.html
@@ -3,7 +3,7 @@
   <div class="element-details">
     <div class="-row"><span>{{ 'unspentOutputs.address' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/address/' + address" class="-link" *ngIf="address">{{ address }}</a> <copy-button [text]="address" *ngIf="address"></copy-button> <span *ngIf="!address">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>{{ 'unspentOutputs.outputsNumber' | translate }}</span><br class="-xs-only" /><div> {{ outputs ? outputs.head_outputs.length : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'unspentOutputs.total' | translate }}</span><br class="-xs-only" /><div> {{ coins != null ? (coins | number:'1.0-6') + ' ' + ('general.coinIdentifier' | translate) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'unspentOutputs.total' | translate }}</span><br class="-xs-only" /><div> <coins-formatter *ngIf="coins" [amount]="coins | number:'1.0-6'"></coins-formatter> <span *ngIf="coins">{{'general.coinIdentifier' | translate}}</span> <span *ngIf="!coins">{{loadingMsg}}</span> </div></div>
   </div>
 </div>
 
@@ -26,7 +26,7 @@
             <div><a [routerLink]="'/app/transaction/' + output.src_tx">{{ output.src_tx }}</a><copy-button [text]="output.src_tx"></copy-button></div>
           </div>
         </div>
-        <div class="col-md-3 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'unspentOutputs.date' | translate }}:<br/></span>{{ output.time | explorerDate }}</div></div>
+        <div class="col-md-3 col-sm-12 -date"><div class="-row"><span class="-xs-sm-only">{{ 'unspentOutputs.date' | translate }}:<br/></span><date-formatter *ngIf="output" [date]="output.time"></date-formatter></div></div>
       </div>
     </div>
 
@@ -35,7 +35,7 @@
         <div class="col-sm-12">
           <div class="-body">
             <div>{{ output.hash }}</div>
-            <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
+            <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> <coins-formatter [amount]="output.coins | number:'1.0-6'"></coins-formatter></div></div>
           </div>
         </div>
       </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -29,6 +29,7 @@
     "richList": "Rich List",
     "time": "Time",
     "blockNumber": "Block Number",
+    "blockNumberSmall": "Block #",
     "transactions": "Transactions",
     "blockhash": "Blockhash"
   },

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -6,6 +6,7 @@ $warning: #ffad1a;
 $gray: #92A4BA;
 
 $text-heading: #394049;
+$gray-text: #92A4BA;
 
 $transparent: 0.25;
 
@@ -35,3 +36,4 @@ $siz-normal-margin: 15px;
 $siz-small-margin: 10px;
 
 $siz-normal-text: 14px;
+$siz-small-text: 12px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,10 @@ h2 {
   float: left;
 }
 
+.-gray {
+  color: $gray-text;
+}
+
 .element-details-wrapper {
 
   width: 100%;
@@ -226,6 +230,12 @@ h2 {
 
   .row {
     margin-bottom: 0;
+    display: flex;
+    align-items: center;
+    
+    a {
+      text-decoration: none;
+    }
   }
 
   .-header {
@@ -244,10 +254,6 @@ h2 {
       &:hover {
         background-color: $col-odd-background-hover;
       }
-    }
-
-    .-gray {
-      color: #92A4BA;
     }
 
     &:hover {


### PR DESCRIPTION
This PR does not change the appearance of the explorer in an important way, but it improves the readability of the data and fixes small errors.

Currently the explorer has problems showing the block page on small screens:

![block1](https://user-images.githubusercontent.com/34079003/41305579-63e025d4-6e41-11e8-8c3a-b8f01a7f718b.png)

This PR fixes the consistency of the lines in the "stats" area and modifies the format of the dates in the table, so that them fits correctly: The PR also vertically centers the content of the tables, to improve the appearance on small screens:

![block2](https://user-images.githubusercontent.com/34079003/41305589-6d54e4c4-6e41-11e8-88f1-ca27d168147e.png)

Also, currently the amounts are difficult to read, since it is difficult to differentiate the commas from the points. The same thing happens to the dates, they are difficult to read because they contain many numbers:

![block3](https://user-images.githubusercontent.com/34079003/41305595-72b4bf52-6e41-11e8-99a9-299323cadf7e.png)

This PR changes the style of the dates and the amouts, to make them easier to read:

![block4](https://user-images.githubusercontent.com/34079003/41305605-782b12ec-6e41-11e8-895f-2ee994c73946.png)

The necessary changes to the e2e tests were also made.