### PR TITLE
Show the initial address balance

### DIFF
--- a/e2e/address-detail/address-detail.e2e-spec.ts
+++ b/e2e/address-detail/address-detail.e2e-spec.ts
@@ -56,6 +56,10 @@ describe('skycoin-explorer Address Page', () => {
     expect(generalFunctions.getTransactionInputsAndOutputsTotalCoins()).toBe(6.002);
   });
 
+  it('should show the correct initial address balance', () => {
+    expect(page.getInitialBalance(0)).toBe(0);
+  });
+
   it('should show the correct final address balance', () => {
     expect(page.getFinalBalance(0)).toBe(0.001);
   });

--- a/e2e/address-detail/address-detail.po.ts
+++ b/e2e/address-detail/address-detail.po.ts
@@ -29,11 +29,20 @@ export class AddressDetailPage {
       .then(text => Number(text.split(' ')[0].replace(new RegExp(',', 'g'), '')));
   }
 
+  getInitialBalance(transsactionIndex: number) {
+    return element
+      .all(by.css('.transaction'))
+      .get(transsactionIndex)
+      .element(by.css('.-balance-variation > div:nth-of-type(1) > div:nth-of-type(3)'))
+      .getText()
+      .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
+  }
+
   getFinalBalance(transsactionIndex: number) {
     return element
       .all(by.css('.transaction'))
       .get(transsactionIndex)
-      .element(by.css('.-final-balance > div > div:nth-of-type(3)'))
+      .element(by.css('.-balance-variation > div:nth-of-type(2) > div:nth-of-type(3)'))
       .getText()
       .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
   }

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -43,7 +43,8 @@ export class Transaction {
   status: boolean;
   timestamp: number;
   balance: number;
-  addressBalance: number;
+  initialBalance: number;
+  finalBalance: number;
   length: number;
 }
 
@@ -97,7 +98,8 @@ export function parseGetAddressTransaction(raw: GetAddressResponseTransaction, a
     outputs: raw.outputs.map(output => parseGetAddressOutput(output)),
     status: raw.status.confirmed,
     balance: balance,
-    addressBalance: null,
+    initialBalance: null,
+    finalBalance: null,
     length: raw.length,
   }
 }
@@ -156,7 +158,8 @@ export function parseGetUnconfirmedTransaction(raw: GetUnconfirmedTransaction): 
     status: raw.is_valid,
     timestamp: new Date(raw.received).getTime(),
     balance: null,
-    addressBalance: null,
+    initialBalance: null,
+    finalBalance: null,
     length: raw.transaction.length,
   }
 }
@@ -191,7 +194,8 @@ function parseGetBlocksTransaction(transaction: GetBlocksResponseBlockBodyTransa
     outputs: transaction.outputs.map(output => parseGetBlocksOutput(output)),
     status: null,
     balance: null,
-    addressBalance: null,
+    initialBalance: null,
+    finalBalance: null,
     length: transaction.length,
   }
 }
@@ -289,7 +293,8 @@ export function parseGetTransaction(raw: GetTransactionResponse): Transaction {
     status: raw.status.confirmed,
     timestamp: raw.txn.timestamp,
     balance: null,
-    addressBalance: null,
+    initialBalance: null,
+    finalBalance: null,
     length: raw.txn.length,
   }
 }

--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -67,8 +67,20 @@
     </div>
     <div class="row">
       <div class="col-sm-12">
-        <div class="-header -xs-only">{{ 'txBoxes.finalBalance' | translate }}</div>
-        <div class="-final-balance"><div><div class="-transparent -not-xs -float-left">{{ 'txBoxes.finalBalance' | translate }}:&nbsp;</div><div class="-transparent -xs-only -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div><coins-formatter [amount]="transaction.addressBalance | number:'1.0-6'"></coins-formatter> </div></div></div>
+        <div class="-header -xs-only">{{ 'txBoxes.balance' | translate }}</div>
+        <div class="-balance-variation">
+          <div>
+            <div class="-transparent -not-xs -float-left">{{ 'txBoxes.initialBalance' | translate }}:&nbsp;</div>
+            <div class="-transparent -xs-only -float-left">{{ 'txBoxes.initialBalanceShort' | translate }}:&nbsp;</div>
+            <div><coins-formatter [amount]="transaction.initialBalance | number:'1.0-6'"></coins-formatter> </div>
+          </div>
+          <span class="separator -not-xs">&#xf105;</span>
+          <div>
+            <div class="-transparent -not-xs -float-left">{{ 'txBoxes.finalBalance' | translate }}:&nbsp;</div>
+            <div class="-transparent -xs-only -float-left">{{ 'txBoxes.finalBalanceShort' | translate }}:&nbsp;</div>
+            <div><coins-formatter [amount]="transaction.finalBalance | number:'1.0-6'"></coins-formatter> </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/services/explorer/explorer.service.ts
+++ b/src/app/services/explorer/explorer.service.ts
@@ -48,8 +48,9 @@ export class ExplorerService {
         let currentBalance = 0;
         return response.reverse().map(rawTx => {
           let parsedTx = parseGetAddressTransaction(rawTx, address);
+          parsedTx.initialBalance = currentBalance;
           currentBalance += parsedTx.balance;
-          parsedTx.addressBalance = currentBalance;
+          parsedTx.finalBalance = currentBalance;
           return parsedTx;
         }).reverse()
       })

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -14,7 +14,11 @@
     "outputs": "Outputs",
     "pending": "pending",
     "date": "Date",
+    "balance": "Balance",
+    "initialBalance": "Initial address balance",
     "finalBalance": "Final address balance",
+    "initialBalanceShort": "Initial",
+    "finalBalanceShort": "Final",
     "firstSeen": "First seen at"
   },
   "blocks": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -188,16 +188,38 @@ h2 {
       }
     }
 
-    .-final-balance {
+    .-balance-variation {
       border-top: 1px solid $col-normal-separator;
-      padding: $siz-small-margin 0px;
       text-align: right;
 
       > div {
         display: inline-block;
+        padding: $siz-small-margin 0px;
+
+        @media (max-width: $max-xs-width) {
+          width: 100%;
+          border-bottom: 1px solid $col-normal-separator;
+          padding: $siz-normal-margin 0;
+  
+          &:last-child {
+            border-bottom: none;
+          }
+        }
+  
+        &:last-child {
+          border-bottom: none;
+        }
+
         > div:last-child {
           display: inline-block;
         }
+      }
+
+      .separator {
+        font-family: 'Font Awesome 5 Free';
+        font-weight: 900;
+        opacity: 0.2;
+        margin: 0 10px
       }
 
       @media (max-width: $max-xs-width) {


### PR DESCRIPTION
Currently, the address page shows the final balance left in the address after each transaction, but not what the initial balance was. Knowing the initial balance makes it much easier to review the transaction history if the address has many transactions. This PR adds that data.

The initial balance looks like this:
![initial1](https://user-images.githubusercontent.com/34079003/41984835-a831293a-79ff-11e8-9501-9cff49cdbb9b.png)

Using small screens it looks like this:
![initial2](https://user-images.githubusercontent.com/34079003/41984844-acd5c432-79ff-11e8-8453-bf13996bf0fc.png)

Also, this pr adapts the e2e test of the final balance and adds a new one, for the initial balance.