### PR TITLE
Improved error messages

### DIFF
--- a/src/app/components/pages/address-detail/address-detail.component.ts
+++ b/src/app/components/pages/address-detail/address-detail.component.ts
@@ -67,8 +67,8 @@ export class AddressDetailComponent implements OnInit {
       },
       error => {
         if (error.status >= 400 && error.status < 500) {
-          this.translate.get(['general.shortLoadingErrorMsg', 'addressDetail.withoutTransactions']).subscribe((res: string[]) => {
-            this.loadingMsg = res['general.shortLoadingErrorMsg'];
+          this.translate.get(['general.noData', 'addressDetail.withoutTransactions']).subscribe((res: string[]) => {
+            this.loadingMsg = res['general.noData'];
             this.longErrorMsg = res['addressDetail.withoutTransactions'];
           });
         } else {

--- a/src/app/components/pages/block-details/block-details.component.ts
+++ b/src/app/components/pages/block-details/block-details.component.ts
@@ -34,21 +34,24 @@ export class BlockDetailsComponent implements OnInit {
 
     this.api.getBlockchainMetadata().first().subscribe(blockchain => this.blockCount = blockchain.blocks);
 
+    let blockID = '';
     this.route.params.filter(params => +params['id'] !== null)
-      .switchMap((params: Params) => this.explorer.getBlock(+params['id']))
-      .subscribe((block: Block) => {
+      .switchMap((params: Params) => {
+        blockID = params['id'];
+        return this.explorer.getBlock(+blockID)
+      }).subscribe((block: Block) => {
         if (block != null)
           this.block = block
         else {
-          this.translate.get(['general.shortLoadingErrorMsg', 'blockDetails.doesNotExist']).subscribe((res: string[]) => {
-            this.loadingMsg = res['general.shortLoadingErrorMsg'];
+          this.translate.get(['general.noData', 'blockDetails.doesNotExist'], {number: blockID}).subscribe((res: string[]) => {
+            this.loadingMsg = res['general.noData'];
             this.longErrorMsg = res['blockDetails.doesNotExist'];
           });
         }
       }, error => {
         if (error.status >= 400 && error.status < 500) {
-          this.translate.get(['general.shortLoadingErrorMsg', 'blockDetails.doesNotExist']).subscribe((res: string[]) => {
-            this.loadingMsg = res['general.shortLoadingErrorMsg'];
+          this.translate.get(['general.noData', 'blockDetails.doesNotExist'], {number: blockID}).subscribe((res: string[]) => {
+            this.loadingMsg = res['general.noData'];
             this.longErrorMsg = res['blockDetails.doesNotExist'];
           });
         } else {

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.ts
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.ts
@@ -33,8 +33,8 @@ export class TransactionDetailComponent implements OnInit {
         transaction => this.transaction = transaction,
         error => {
           if (error.status >= 400 && error.status < 500) {
-            this.translate.get(['general.shortLoadingErrorMsg', 'transactionDetail.canNotFind']).subscribe((res: string[]) => {
-              this.loadingMsg = res['general.shortLoadingErrorMsg'];
+            this.translate.get(['general.noData', 'transactionDetail.canNotFind']).subscribe((res: string[]) => {
+              this.loadingMsg = res['general.noData'];
               this.longErrorMsg = res['transactionDetail.canNotFind'];
             });
           } else {

--- a/src/app/components/pages/unspent-outputs/unspent-outputs.component.ts
+++ b/src/app/components/pages/unspent-outputs/unspent-outputs.component.ts
@@ -38,8 +38,8 @@ export class UnspentOutputsComponent implements OnInit {
       this.coins = response.head_outputs.reduce((a, b) => a + parseFloat(b.coins), 0);
     }, error => {
       if (error.status >= 400 && error.status < 500) {
-        this.translate.get(['general.shortLoadingErrorMsg', 'unspentOutputs.withoutOutputs']).subscribe((res: string[]) => {
-          this.loadingMsg = res['general.shortLoadingErrorMsg'];
+        this.translate.get(['general.noData', 'unspentOutputs.withoutOutputs']).subscribe((res: string[]) => {
+          this.loadingMsg = res['general.noData'];
           this.longErrorMsg = res['unspentOutputs.withoutOutputs'];
         });
       } else {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -6,7 +6,8 @@
     "loadingMsg": "Loading...",
     "shortLoadingErrorMsg": "Loading error",
     "longLoadingErrorMsg": "Error loading data, try again later...",
-    "waitingData": "Waiting for data..."
+    "waitingData": "Waiting for data...",
+    "noData": "No data to show"
   },
   "txBoxes": {
     "transactionID": "Transaction ID",
@@ -44,7 +45,7 @@
     "parentHash": "Parent Hash",
     "totalAmount": "Total Amount",
     "withoutParent": "Without parent block",
-    "doesNotExist": "The block does not exist"
+    "doesNotExist": "The block \"{{number}}\" does not exist"
   },
   "addressDetail": {
     "title": "Address",


### PR DESCRIPTION
Currently, when searching for an item that does not exist, the explorer shows "Loading error" in several parts. For example, if you search for the details of a block that does not exist, this is displayed:
![err1](https://user-images.githubusercontent.com/34079003/42001255-7775aa78-7a31-11e8-86eb-d9ddf36116d1.png)

This happens in the block details, transaction, address and outputs pages.

This PR changes the message to "No data to show", a more appropriate message for the UX, since the current one may suggest that there was an error with the system:
![err2](https://user-images.githubusercontent.com/34079003/42001257-797116d2-7a31-11e8-943e-372b6c4e34e8.png)

Additionally, the message shown when looking for a block that does not exist was improved.

