### PR TITLE
fixes #213 - Improved search capabilities

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -6,6 +6,12 @@ The explorer is designed in such a way that it is possible to make simple custom
 
 To simplify copying addresses with mobile devices, the explorer shows qr codes. The qr codes contain the addresses prefixed with the name of the coin, in this way: `skycoin:abcd...` (More information in this link: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki). If needed, the `skycoin:` prefix can be changed by modifying the value of `QrConfig.prefix`, inside [app.config.ts](src/app/app.config.ts).
 
+## Search functionality
+
+The explorer is integrated with the browser's search functionality. This means that the user can search for elements of the blockchain directly from the search functionality of the browser. For this to work properly, you must modify the [search.xml](src/search.xml) file. Simply replace the `https://explorer.skycoin.net/` prefix of all URLs with the URL where the browser will reside (it is not necessary to replace the text that may be to the right of that prefix). Also, replace the `ShortName` and `Description` as deemed necessary.
+
+You can find more information about the file format in [opensearch-1-1-draft-6.md](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md)
+
 ## Colors and general appearance
 
 Most explorer colors and other general UI parameters are defined in [_variables.scss](src/assets/scss/_variables.scss). Making changes to that file is the quickest way to change the explorer appearance.

--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,8 @@
             "polyfills": "src/polyfills.ts",
             "assets": [
               "src/assets",
-              "src/favicon.ico"
+              "src/favicon.ico",
+              "src/search.dev.xml"
             ],
             "styles": [
               "src/assets/css/bootstrap.min.css",
@@ -46,6 +47,11 @@
                   "replace": "src/environments/environment.ts",
                   "with": "src/environments/environment.prod.ts"
                 }
+              ],
+              "assets": [
+                "src/assets",
+                "src/favicon.ico",
+                "src/search.xml"
               ]
             }
           }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,8 @@ import { ExplorerDatePipe } from 'app/pipes/explorer-date.pipe';
 import { DatePipe } from '@angular/common';
 import { CoinsFormatterComponent } from 'app/components/layout/coins-formatter/coins-formatter.component';
 import { DateFormatterComponent } from 'app/components/layout/date-formatter/date-formatter.component';
+import { SearchService } from './services/search/search.service';
+import { SearchComponent } from './components/pages/search/search.component';
 
 
 const ROUTES = [
@@ -76,6 +78,15 @@ const ROUTES = [
     path: 'app/unspent/:address',
     component: UnspentOutputsComponent
   },
+  {
+    path: 'app/search',
+    redirectTo: 'app/blocks/1',
+    pathMatch: 'full'
+  },
+  {
+    path: 'app/search/:term',
+    component: SearchComponent
+  },
 ];
 
 @NgModule({
@@ -100,6 +111,7 @@ const ROUTES = [
     ExplorerDatePipe,
     CoinsFormatterComponent,
     DateFormatterComponent,
+    SearchComponent,
   ],
   imports: [
     BrowserModule,
@@ -117,6 +129,7 @@ const ROUTES = [
   providers: [
     ApiService,
     ExplorerService,
+    SearchService,
     {provide: RouteReuseStrategy, useClass: AppReuseStrategy},
     DatePipe,
   ],

--- a/src/app/components/layout/search-bar/search-bar.component.html
+++ b/src/app/components/layout/search-bar/search-bar.component.html
@@ -1,6 +1,7 @@
 <form (submit)="search()">
   <div class="-search-bar-container">
-    <img src="/assets/img/search.png" (click)="search()">
+    <img src="/assets/img/search.png" (click)="search()" *ngIf="!searching" />
+    <i class="fa fa-spinner fa-spin fa-fw" *ngIf="searching"></i>
     <input [(ngModel)]="query" name="query" placeholder="{{ 'searchBar.hint' | translate }}">
   </div>
 </form>

--- a/src/app/components/layout/search-bar/search-bar.component.scss
+++ b/src/app/components/layout/search-bar/search-bar.component.scss
@@ -9,6 +9,12 @@
     position: absolute;
   }
 
+  i {
+    margin: 13px 11px;
+    position: absolute;
+    font-size: 17px;
+  }
+
   input {
     border: 2px solid rgba(0, 0, 0, 0.05);
     border-radius: 6px;

--- a/src/app/components/pages/search/search.component.html
+++ b/src/app/components/pages/search/search.component.html
@@ -1,0 +1,10 @@
+<h2>{{ 'search.title' | translate }}</h2>
+
+<div class="row -msg-container">
+  <div class="col-sm-12">
+    <span *ngIf="!errorMsg">
+      {{ 'general.waitingData' | translate }} <i class="fa fa-spinner fa-spin fa-fw"></i>
+    </span>
+    <span *ngIf="errorMsg">{{ errorMsg | translate:{ term: searchTerm } }}</span>
+  </div>
+</div>

--- a/src/app/components/pages/search/search.component.spec.ts
+++ b/src/app/components/pages/search/search.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SearchComponent } from './search.component';
+
+describe('BlockChainTableComponent', () => {
+  let component: SearchComponent;
+  let fixture: ComponentFixture<SearchComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SearchComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SearchComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/search/search.component.ts
+++ b/src/app/components/pages/search/search.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Params, Router } from '@angular/router';
+
+import { SearchService, SearchError } from '../../../services/search/search.service';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  templateUrl: './search.component.html',
+})
+export class SearchComponent implements OnInit {
+
+  searchTerm = '';
+  errorMsg: string;
+
+  constructor(
+    private searchService: SearchService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private translate: TranslateService,
+  ) {}
+
+  ngOnInit() {
+    this.route.params.first()
+      .subscribe((params: Params) => {
+        if (!params['term'] || (params['term'].trim() as string).length < 1) {
+          this.errorMsg = 'search.unableToFind'
+        }
+        this.searchTerm = params['term'].trim();
+
+        const navCommands = this.searchService.getResultNavCommands(this.searchTerm);
+        if (navCommands.error) {
+          if (navCommands.error == SearchError.InvalidSearchTerm) {
+            this.errorMsg = 'search.unableToFind'
+          }
+          return;
+        }
+
+        navCommands.resultNavCommands.subscribe(
+          navCommands => this.router.navigate(navCommands, { replaceUrl: true }),
+          err => this.errorMsg = 'search.unableToFind'
+        );
+      })
+  }
+}

--- a/src/app/services/search/search.service.spec.ts
+++ b/src/app/services/search/search.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SearchService]
+    });
+  });
+
+  it('should be created', inject([SearchService], (service: SearchService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/search/search.service.ts
+++ b/src/app/services/search/search.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import { ExplorerService } from '../explorer/explorer.service';
+
+@Injectable()
+export class SearchService {
+
+  constructor(
+    private explorer: ExplorerService,
+  ) { }
+
+  getResultNavCommands(searchTerm: string): ResultNavCommandsResponse {
+    const response = new ResultNavCommandsResponse();
+    searchTerm = encodeURIComponent(searchTerm);
+
+    if (searchTerm.length >= 27 && searchTerm.length <= 35) {
+      response.resultNavCommands = Observable.of(['/app/address', searchTerm]);
+    } else if (searchTerm.length === 64) {
+      response.resultNavCommands = this.explorer.getBlockByHash(searchTerm)
+        .map(block => ['/app/block', block.id.toString()])
+        .catch((error: any) => {
+          if (error && error.status && error.status == 404) {
+            return Observable.of(['/app/transaction', searchTerm]);
+          } else {
+            return Observable.throw(error);
+          }
+        });
+    } else {
+      if (parseInt(searchTerm, 10).toString() == searchTerm && parseInt(searchTerm, 10) >= 0) {
+        response.resultNavCommands = Observable.of(['/app/block', searchTerm]);
+      } else {
+        response.error = SearchError.InvalidSearchTerm;
+      }
+    }
+
+    return response;
+  }
+
+}
+
+export class ResultNavCommandsResponse {
+  resultNavCommands: Observable<string[]>;
+  error: SearchError;
+}
+
+export enum SearchError {
+  InvalidSearchTerm = 1,
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -95,5 +95,9 @@
   },
   "searchBar": {
     "hint": "Address, block hash or number, or transaction ID"
+  },
+  "search": {
+    "title": "Search",
+    "unableToFind": "Unable to find \"{{ term }}\""
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,10 @@
 export const environment = {
   production: true
 };
+
+const searchLink = document.createElement('link');
+searchLink.type = 'application/opensearchdescription+xml';
+searchLink.rel = 'search';
+searchLink.href = 'search.xml';
+searchLink.title = 'Skycoin Explorer';
+document.head.appendChild(searchLink);

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,3 +6,10 @@
 export const environment = {
   production: false
 };
+
+const searchLink = document.createElement('link');
+searchLink.type = 'application/opensearchdescription+xml';
+searchLink.rel = 'search';
+searchLink.href = 'search.dev.xml';
+searchLink.title = 'Skycoin Explorer Test';
+document.head.appendChild(searchLink);

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="assets/styles.css" type="text/css" rel="stylesheet" media="screen,projection"/>
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/x-icon" href="favicon.ico"/>
 </head>
 <body>
   <app-root></app-root>

--- a/src/search.dev.xml
+++ b/src/search.dev.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <script/>
+  <ShortName>Skycoin Explorer Test</ShortName>
+  <Description>Search the Skycoin blockchain</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/vnd.microsoft.icon">http://localhost:4200/favicon.ico</Image>
+  <Url type="text/html" template="http://localhost:4200/app/search/{searchTerms}" />
+  <moz:SearchForm>http://localhost:4200/</moz:SearchForm>
+</OpenSearchDescription>

--- a/src/search.xml
+++ b/src/search.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <script/>
+  <ShortName>Skycoin Explorer</ShortName>
+  <Description>Search the Skycoin blockchain</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/vnd.microsoft.icon">https://explorer.skycoin.net/favicon.ico</Image>
+  <Url type="text/html" template="https://explorer.skycoin.net/app/search/{searchTerms}" />
+  <moz:SearchForm>https://explorer.skycoin.net/</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Fixes #213 

Changes:
- This PR integrates the explorer to the browser's search functionality. In Google Chrome it is possible to search using the Omnibox and in Firefox you can add the explorer as a search engine:
![search](https://user-images.githubusercontent.com/34079003/42415622-d6886e80-8222-11e8-90f0-c20081a320f6.png)

- In the previous image "Test" appears after "Skycoin Explorer" because this PR includes two configurations. While using a production build, the searches are done in https://explorer.skycoin.net and the text "Test" disappears. While using a develoment build, the searches are done in http://localhost:4200 (the default URL of the test server) and the text "Test" appears.

- Added information in `CUSTOMIZATION.md` about how to edit `search.xml`, to make the search functionality work if the browser is hosted on another URL.

- The code that built the search URLs was moved from `SearchBarComponent` to `SearchService`, to use it also in the new search functions while complying with the DRY philosophy.

- General improvements to the search code. Now the code is much more robust and reacts more adequately in case of errors, slow internet connection, wrong inputs, etc.