### PR TITLE
[ci] fixes #219 - Travis builds for golang 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ addons:
 
 before_install:
   - nvm install 8.9
-  - go version
 
 install:
   - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 
 go:
-  - 1.8
-  - 1.9
-  - 1.10
+  - "1.8"
+  - "1.9"
+  - "1.10"
 
 env:
   - SKYCOIN_ADDR=http://172.17.0.2:6420
@@ -20,6 +20,7 @@ addons:
 
 before_install:
   - nvm install 8.9
+  - go version
 
 install:
   - go get -t ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.8
   - 1.9
+  - 1.10
 
 env:
   - SKYCOIN_ADDR=http://172.17.0.2:6420


### PR DESCRIPTION
Fixes #219 

Changes:
- Added golang 1.10 to travis's matrix

Does this change need to mentioned in CHANGELOG.md?
No