### PR TITLE
Fix style problems

### DIFF
--- a/src/app/components/pages/richlist/richlist.component.scss
+++ b/src/app/components/pages/richlist/richlist.component.scss
@@ -1,0 +1,5 @@
+.table {
+  a {
+    text-decoration: none;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -44,7 +44,7 @@ h2 {
         padding-top: 0;
       }
 
-      > span:first-child {
+      > span:first-of-type {
         display: block;
         float: left;
         color: $gray;


### PR DESCRIPTION
Changes:
- Fix a problem that made the elements of the rich list to be underlined when the mouse is over, in Chrome.

- Fix a problem that made the small "Address" text, on the address details page, to have an incorrect color (only visible when the browser window is very small):
![text-color](https://user-images.githubusercontent.com/34079003/43787422-efd95bc8-9a38-11e8-8be9-85aa12fe8927.png)
