### PR TITLE
Show tx fee

### DIFF
--- a/e2e/address-detail/address-detail.po.ts
+++ b/e2e/address-detail/address-detail.po.ts
@@ -39,7 +39,7 @@ export class AddressDetailPage {
     return element
       .all(by.css('.transaction'))
       .get(transsactionIndex)
-      .element(by.css('.-balance-variation > div:nth-of-type(1) > div:nth-of-type(3)'))
+      .element(by.css('.-balance-variation > div:nth-of-type(2) > div:nth-of-type(2)'))
       .getText()
       .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
   }
@@ -48,7 +48,7 @@ export class AddressDetailPage {
     return element
       .all(by.css('.transaction'))
       .get(transsactionIndex)
-      .element(by.css('.-balance-variation > div:nth-of-type(2) > div:nth-of-type(3)'))
+      .element(by.css('.-balance-variation > div:nth-of-type(3) > div:nth-of-type(2)'))
       .getText()
       .then(text => Number(text.replace(new RegExp(',', 'g'), '')));
   }

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -50,6 +50,7 @@ export class Transaction {
   initialBalance: number;
   finalBalance: number;
   length: number;
+  fee: number;
 }
 
 export class Wallet {
@@ -151,6 +152,7 @@ export function parseGenericTransaction(raw: GenericTransactionResponse, address
     initialBalance: null,
     finalBalance: null,
     length: raw.length,
+    fee: raw.fee,
   }
 
   if (raw.status) {

--- a/src/app/components/pages/address-detail/address-detail.component.html
+++ b/src/app/components/pages/address-detail/address-detail.component.html
@@ -74,15 +74,17 @@
       <div class="col-sm-12">
         <div class="-header -xs-only">{{ 'txBoxes.balance' | translate }}</div>
         <div class="-balance-variation">
+          <div class="fee-box">
+            <div class="-transparent -float-left">{{ 'txBoxes.fee' | translate }}:&nbsp;</div>
+            <div>{{ transaction.fee | number:'1.0-0' }}</div>
+          </div>
           <div>
-            <div class="-transparent -not-xs -float-left">{{ 'txBoxes.initialBalance' | translate }}:&nbsp;</div>
-            <div class="-transparent -xs-only -float-left">{{ 'txBoxes.initialBalanceShort' | translate }}:&nbsp;</div>
+            <div class="-transparent -float-left">{{ 'txBoxes.initialBalance' | translate }}:&nbsp;</div>
             <div>{{ transaction.initialBalance | number:'1.0-6' }}</div>
           </div>
           <span class="separator -not-xs">&#xf105;</span>
           <div>
-            <div class="-transparent -not-xs -float-left">{{ 'txBoxes.finalBalance' | translate }}:&nbsp;</div>
-            <div class="-transparent -xs-only -float-left">{{ 'txBoxes.finalBalanceShort' | translate }}:&nbsp;</div>
+            <div class="-transparent -float-left">{{ 'txBoxes.finalBalance' | translate }}:&nbsp;</div>
             <div>{{ transaction.finalBalance | number:'1.0-6' }}</div>
           </div>
         </div>

--- a/src/app/components/pages/block-details/block-details.component.html
+++ b/src/app/components/pages/block-details/block-details.component.html
@@ -71,6 +71,17 @@
           </div>
         </div>
       </div>
+      <div class="row">
+        <div class="col-sm-12">
+          <div class="-header -xs-only">{{ 'txBoxes.balance' | translate }}</div>
+          <div class="-balance-variation">
+            <div class="fee-box">
+              <div class="-transparent -float-left">{{ 'txBoxes.fee' | translate }}:&nbsp;</div>
+              <div>{{ transaction.fee | number:'1.0-0' }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -57,5 +57,16 @@
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="-header -xs-only">{{ 'txBoxes.balance' | translate }}</div>
+        <div class="-balance-variation">
+          <div class="fee-box">
+            <div class="-transparent -float-left">{{ 'txBoxes.fee' | translate }}:&nbsp;</div>
+            <div>{{ transaction.fee | number:'1.0-0' }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
+++ b/src/app/components/pages/unconfirmed-transactions/unconfirmed-transactions.component.html
@@ -57,5 +57,16 @@
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="-header -xs-only">{{ 'txBoxes.balance' | translate }}</div>
+        <div class="-balance-variation">
+          <div class="fee-box">
+            <div class="-transparent -float-left">{{ 'txBoxes.fee' | translate }}:&nbsp;</div>
+            <div>{{ transaction.fee | number:'1.0-0' }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -18,11 +18,10 @@
     "outputs": "Outputs",
     "pending": "pending",
     "date": "Date",
-    "balance": "Balance",
-    "initialBalance": "Initial address balance",
-    "finalBalance": "Final address balance",
-    "initialBalanceShort": "Initial",
-    "finalBalanceShort": "Final",
+    "balance": "More info",
+    "fee": "Transaction fee (in hours)",
+    "initialBalance": "Initial coins balance",
+    "finalBalance": "Final coins balance",
     "firstSeen": "First seen at"
   },
   "blocks": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -191,10 +191,17 @@ h2 {
     .-balance-variation {
       border-top: 1px solid $col-normal-separator;
       text-align: right;
+      display: flex;
+      align-items: center;
+
+      .fee-box {
+        flex-grow: 1;
+      }
 
       > div {
         display: inline-block;
         padding: $siz-small-margin 0px;
+        text-align: left;
 
         @media (max-width: $max-xs-width) {
           width: 100%;
@@ -226,6 +233,7 @@ h2 {
         & {
           border-top: none;
           text-align: left;
+          display: unset;
         }
       }
     }


### PR DESCRIPTION
Changes:
- Now the system indicates what the fee (in hours) of the transactions was. The change was done in the block details page, the transaction details page, the pending transactions page and the address details page.
![fee1](https://user-images.githubusercontent.com/34079003/46583737-47179d80-ca29-11e8-836e-f88ff69c7ef3.png)
![fee2](https://user-images.githubusercontent.com/34079003/46583738-4aab2480-ca29-11e8-933b-d0d074e09637.png)

- The text of the initial and final balances of the address was changed a little in the address details page, in order to make it a little clearer, because there are now values in coins and in hours. In the current version it looks like this:
![txt1](https://user-images.githubusercontent.com/34079003/46583836-6d8a0880-ca2a-11e8-8b62-93e57d4a853f.png)
![txt2](https://user-images.githubusercontent.com/34079003/46583838-6fec6280-ca2a-11e8-90a3-d917c9f94a3b.png)

