### PR TITLE
Fix normal e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e",
+    "e2e": "ng e2e skycoin-explorer-e2e",
     "e2e-blockchain-180": "ng e2e skycoin-explorer-e2e-blockchain-180",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -9,7 +9,10 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+    chromeOptions: {
+      args: ['window-size=1920,1080']
+    }
   },
   directConnect: true,
   baseUrl: 'http://127.0.0.1:8001/',


### PR DESCRIPTION
In this repository it is possible to execute e2e tests with both `npm run e2e` and `npm run e2e-blockchain-180`. `npm run e2e-blockchain-180` is used to run the tests in Travis, using a limited and controlled database, but that command is inconvenient to run the tests during normal development, because it involves using a node with `blockchain-180.db`, that's why `npm run e2e` exists, to be able to run the tests with a normal node.

This PR makes the configuration of `npm run e2e` to be more similar to that of `npm run e2e-blockchain-180`, to avoid some problems that occurred only when executing `npm run e2e`.