### PR TITLE
Add the "Show all" option

### DIFF
--- a/src/app/components/layout/transaction-info/transaction-info.component.html
+++ b/src/app/components/layout/transaction-info/transaction-info.component.html
@@ -1,4 +1,4 @@
-<div class="transaction">
+<div class="transaction" [ngClass]="{'disable-clicks' : disableClicks}">
   <div class="-title">
     <div class="row">
       <div class="col-md-10 col-sm-12">
@@ -34,8 +34,8 @@
           <div class="-balance"><div class="-transparent -float-left">{{ 'general.iniialHours' | translate }}:&nbsp;</div><div> {{ input.hours | number:'1.0-6' }}</div></div>
           <div class="-balance"><div class="-transparent -float-left">{{ 'general.calculatedHours' | translate }}:&nbsp;</div><div> {{ input.calculatedHours | number:'1.0-6' }}</div></div>
         </div>
-        <div class="-body" *ngIf="nextInputsGroup">
-          <a class="-link" (click)="showMoreInputs()">{{ 'txBoxes.loadMore' | translate:{ number: nextInputsGroup, total: totalInputs } }}</a>
+        <div class="-body" *ngIf="showMoreInputs !== showMoreStatus.DontShowMore">
+          <a class="-link" (click)="startShowingAllInputs()">{{ showMoreInputs === showMoreStatus.ShowMore ? ('txBoxes.loadAll' | translate:{ total: totalInputs }) : ('txBoxes.loading' | translate) }}</a>
         </div>
       </div>
       <div class="col-sm-6">
@@ -45,8 +45,8 @@
           <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
           <div class="-balance"><div class="-transparent -float-left">{{ 'general.hours' | translate }}:&nbsp;</div><div> {{ output.hours | number:'1.0-6' }}</div></div>
         </div>
-        <div class="-body" *ngIf="nextOutputsGroup">
-          <a class="-link" (click)="showMoreOutputs()">{{ 'txBoxes.loadMore' | translate:{ number: nextOutputsGroup, total: totalOutputs } }}</a>
+        <div class="-body" *ngIf="showMoreOutputs !== showMoreStatus.DontShowMore">
+          <a class="-link" (click)="startShowingAllOutputs()">{{ showMoreOutputs === showMoreStatus.ShowMore ? ('txBoxes.loadAll' | translate:{ total: totalOutputs }) : ('txBoxes.loading' | translate) }}</a>
         </div>
       </div>
     </div>

--- a/src/app/components/layout/transaction-info/transaction-info.component.scss
+++ b/src/app/components/layout/transaction-info/transaction-info.component.scss
@@ -1,0 +1,4 @@
+.disable-clicks {
+  pointer-events: none;
+  opacity: 0.7;
+}

--- a/src/app/components/layout/transaction-info/transaction-info.component.ts
+++ b/src/app/components/layout/transaction-info/transaction-info.component.ts
@@ -1,5 +1,10 @@
 import { Component, Input } from '@angular/core';
-import { HeaderConfig } from 'app/app.config';
+
+enum ShowMoreStatus {
+  ShowMore = 0,
+  Loading = 1,
+  DontShowMore = 2,
+}
 
 @Component({
   selector: 'transaction-info',
@@ -7,14 +12,16 @@ import { HeaderConfig } from 'app/app.config';
   styleUrls: ['./transaction-info.component.scss']
 })
 export class TransactionInfoComponent {
-  private maxElements = 10;
+  private readonly maxInitialElements = 10;
   private transactionInternal: any;
 
+  disableClicks = false;
+  showMoreStatus = ShowMoreStatus;
   totalInputs = 0;
-  nextInputsGroup = 0;
+  showMoreInputs: ShowMoreStatus = ShowMoreStatus.DontShowMore;
   inputsToShow: any[] = [];
   totalOutputs = 0;
-  nextOutputsGroup = 0;
+  showMoreOutputs: ShowMoreStatus = ShowMoreStatus.DontShowMore;
   outputsToShow: any[] = [];
 
   @Input()
@@ -24,8 +31,8 @@ export class TransactionInfoComponent {
     this.totalInputs = this.transaction.inputs.length;
     this.totalOutputs = this.transaction.outputs.length;
 
-    this.showMoreInputs();
-    this.showMoreOutputs();
+    this.showInitialInputs();
+    this.showInitialOutputs();
   }
   get transaction(): any {
     return this.transactionInternal;
@@ -35,19 +42,53 @@ export class TransactionInfoComponent {
   
   constructor() { }
 
-  showMoreInputs() {
-    const currentNumber = this.inputsToShow.length;
-    for (let i=currentNumber; i<Math.min(currentNumber + this.maxElements, this.totalInputs); i++) {
-      this.inputsToShow.push(this.transaction.inputs[i]);
+  showInitialInputs() {
+    if (this.totalInputs > this.maxInitialElements) {
+      for (let i=0; i<this.maxInitialElements; i++) {
+        this.inputsToShow.push(this.transaction.inputs[i]);
+      }
+      this.showMoreInputs = ShowMoreStatus.ShowMore;
+    } else {
+      this.showAllInputs();
     }
-    this.nextInputsGroup = Math.min(this.totalInputs - this.inputsToShow.length, this.maxElements);
   }
 
-  showMoreOutputs() {
-    const currentNumber = this.outputsToShow.length;
-    for (let i=currentNumber; i<Math.min(currentNumber + this.maxElements, this.totalOutputs); i++) {
-      this.outputsToShow.push(this.transaction.outputs[i]);
+  showInitialOutputs() {
+    if (this.totalOutputs > this.maxInitialElements) {
+      for (let i=0; i<this.maxInitialElements; i++) {
+        this.outputsToShow.push(this.transaction.outputs[i]);
+      }
+      this.showMoreOutputs = ShowMoreStatus.ShowMore;
+    } else {
+      this.showAllOutputs();
     }
-    this.nextOutputsGroup = Math.min(this.totalOutputs - this.outputsToShow.length, this.maxElements);
+  }
+
+  startShowingAllInputs() {
+    this.disableClicks = true;
+    this.showMoreInputs = ShowMoreStatus.Loading;
+    setTimeout(() => this.showAllInputs(), 32);
+  }
+
+  startShowingAllOutputs() {
+    this.disableClicks = true;
+    this.showMoreOutputs = ShowMoreStatus.Loading;
+    setTimeout(() => this.showAllOutputs(), 32);
+  }
+
+  private showAllInputs() {
+    this.inputsToShow = this.transaction.inputs;
+    setTimeout(() => {
+      this.showMoreInputs = ShowMoreStatus.DontShowMore;
+      this.disableClicks = false;
+    });
+  }
+
+  private showAllOutputs() {
+    this.outputsToShow = this.transaction.outputs;
+    setTimeout(() => {
+      this.showMoreOutputs = ShowMoreStatus.DontShowMore;
+      this.disableClicks = false;
+    });
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -23,7 +23,8 @@
     "initialBalance": "Initial coins balance",
     "finalBalance": "Final coins balance",
     "firstSeen": "First seen at",
-    "loadMore": "Load {{number}} more ({{total}} in total)"
+    "loadAll": "Show all {{total}} elements",
+    "loading": "Loading, please wait..."
   },
   "blocks": {
     "blocksTitle": "Blocks",


### PR DESCRIPTION
Continuing from https://github.com/skycoin/skycoin-explorer/pull/247#issuecomment-430507998

Changes:
Now when a transaction has too many outputs or inputs, instead of showing them in groups of 10, the user has the option to show all the elements:
![show-all](https://user-images.githubusercontent.com/34079003/47091098-3538b600-d1f2-11e8-999d-941877d85694.png)
As showing too many elements is an intensive task for Angular, while the processing is done, a loading message is displayed and the click events are deactivated (this is due to the fact that the waiting time could cause some users to press the link again and have an unwanted redirect just after Angular finishes processing and the browser render process is no longer busy):
![loading](https://user-images.githubusercontent.com/34079003/47091507-f7885d00-d1f2-11e8-89e5-c3c151b89383.png)
As the transactions with many outputs or inputs are rare, this is a behavior that should be infrequent.