### PR TITLE
Show the hours on the unspent outputs page

### DIFF
--- a/e2e/unspent-outputs/unspent-outputs.e2e-spec.ts
+++ b/e2e/unspent-outputs/unspent-outputs.e2e-spec.ts
@@ -15,8 +15,8 @@ describe('skycoin-explorer Unspent Outputs Page', () => {
     expect(generalFunctions.getPageTitle()).toBe('Unspent Outputs');
   });
 
-  it('should display 3 details rows', () => {
-    expect(generalFunctions.getDetailsRowCount()).toEqual(3);
+  it('should display 4 details rows', () => {
+    expect(generalFunctions.getDetailsRowCount()).toEqual(4);
   });
 
   it('should show the correct address', () => {
@@ -57,9 +57,9 @@ describe('skycoin-explorer Unspent Outputs Page', () => {
 
   it('should have the correct coins amount', () => {
     if (browser.params.chain === '180') {
-      expect(generalFunctions.getTransactionInputsAndOutputsTotalCoins()).toBe(100);
+      expect(page.getOutputsTotalCoins()).toBe(100);
     } else {
-      expect(generalFunctions.getTransactionInputsAndOutputsTotalCoins()).toBe(0.001);
+      expect(page.getOutputsTotalCoins()).toBe(0.001);
     }
   });
 

--- a/e2e/unspent-outputs/unspent-outputs.po.ts
+++ b/e2e/unspent-outputs/unspent-outputs.po.ts
@@ -26,4 +26,14 @@ export class UnspentOutputsPage {
       .element(by.css('.-data > .row .-body div'))
       .getText();
   }
+
+  getOutputsTotalCoins() {
+    return element
+      .all(by.css('.-balance'))
+      .get(0)
+      .all(by.css('div:nth-of-type(2)'))
+      .map((elem, i) => elem.getText())
+      .then(texts => texts.map(text => Number((text as string).replace(new RegExp(',', 'g'), ''))).reduce((total, val) => total + val, 0))
+      .then(result => Math.round(result * 1000000) / 1000000);
+  }
 }

--- a/explorer.go
+++ b/explorer.go
@@ -672,27 +672,46 @@ var apiEndpoints = []APIEndpoint{
 		Description:    "Returns head outputs for a list of comma-separated addresses.  If no addresses are specified, returns all head outputs.",
 		ExampleRequest: "/api/currentBalance?addrs=SeDoYN6SNaTiAZFHwArnFwQmcyz7ZvJm17,iqi5BpPhEqt35SaeMLKA94XnzBG57hToNi",
 		ExampleResponse: `{
+    "head": {
+      "seq": 65796,
+      "block_hash": "3c869dfad2fdea444fe53f888c20ead67c5b0fccd8da34c3d7da580bc8a6d23c",
+      "previous_block_hash": "8dce9985e05f3ac648a0a17dd60bda2737395d646b1cb42f3039eccde2a6ce7a",
+      "timestamp": 1540423494,
+      "fee": 6892,
+      "version": 0,
+      "tx_body_hash": "bd9ea7068c96ca065f511635cddcc0fb7e13bdf0b5889dd52889292ca9e2a116",
+      "ux_hash": "572660420c0b463d00a1d87f320c9390456bbc93bc8be1e16808a3116f2152bc"
+    },
     "head_outputs": [
         {
             "hash": "fa8161308dee3accc99a35be1fb7921dff4d24a6fc804e98d7aae7aae99d0d0d",
+            "time": 1540423494,
+            "block_seq": 65796,
             "src_tx": "b125abb61f5d6ec0f44422e234007b07ab276923e9533023bdd58d51e0a0f9b7",
             "address": "iqi5BpPhEqt35SaeMLKA94XnzBG57hToNi",
             "coins": "50",
-            "hours": 248
+            "hours": 248,
+            "calculated_hours": 3445
         },
         {
             "hash": "38926afbb00c2f50d293de866bc44713eaa14c18286b24796819fbc190efcbce",
+            "time": 1540423494,
+            "block_seq": 50000,
             "src_tx": "8591837d905894142119923de1447ba855dcf8f34ba451970e83a2bbfea8eeca",
             "address": "iqi5BpPhEqt35SaeMLKA94XnzBG57hToNi",
             "coins": "375",
-            "hours": 9
+            "hours": 9,
+            "calculated_hours": 3445
         },
         {
             "hash": "a70d1f0f488066a327acd0d5ea77b87d62b3b061d3db8361c90194a6520ab29f",
+            "time": 1540423494,
+            "block_seq": 20000,
             "src_tx": "c297eb14a9e68ec5501aa886e5bb720a58fe6466be633a8264f61eee9580a2c3",
             "address": "SeDoYN6SNaTiAZFHwArnFwQmcyz7ZvJm17",
             "coins": "51",
-            "hours": 2013433
+            "hours": 2013433,
+            "calculated_hours": 3000000
         }
     ],
     "outgoing_outputs": [],

--- a/src/app/app.datatypes.ts
+++ b/src/app/app.datatypes.ts
@@ -220,6 +220,7 @@ class GetCurrentBalanceResponseOutput {
   address: string;
   coins: string;
   hours: number;
+  calculated_hours: number;
 }
 
 export class GetTransactionResponse {

--- a/src/app/components/pages/unspent-outputs/unspent-outputs.component.html
+++ b/src/app/components/pages/unspent-outputs/unspent-outputs.component.html
@@ -3,7 +3,8 @@
   <div class="element-details">
     <div class="-row"><span>{{ 'unspentOutputs.address' | translate }}</span><br class="-xs-only" /><div> <a [routerLink]="'/app/address/' + address" class="-link" *ngIf="address">{{ address }}</a> <app-copy-button [text]="address" *ngIf="address"></app-copy-button> <span *ngIf="!address">{{ loadingMsg }}</span> </div></div>
     <div class="-row"><span>{{ 'unspentOutputs.outputsNumber' | translate }}</span><br class="-xs-only" /><div> {{ outputs ? outputs.head_outputs.length : loadingMsg }} </div></div>
-    <div class="-row"><span>{{ 'unspentOutputs.total' | translate }}</span><br class="-xs-only" /><div> {{ coins != null ? (coins.decimalPlaces(6).toString() | number:'1.0-6') + ' ' + ('general.coinIdentifier' | translate) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'unspentOutputs.totalCoins' | translate }}</span><br class="-xs-only" /><div> {{ coins != null ? (coins.decimalPlaces(6).toString() | number:'1.0-6') + ' ' + ('general.coinIdentifier' | translate) : loadingMsg }} </div></div>
+    <div class="-row"><span>{{ 'unspentOutputs.totalHours' | translate }}</span><br class="-xs-only" /><div> {{ hours != null ? (hours.decimalPlaces(0).toString() | number:'1.0-0') : loadingMsg }} </div></div>
   </div>
 </div>
 
@@ -29,6 +30,8 @@
           <div class="-body">
             <div>{{ output.hash }}</div>
             <div class="-balance"><div class="-transparent -float-left">{{ 'general.coins' | translate }}:&nbsp;</div><div> {{ output.coins | number:'1.0-6' }}</div></div>
+            <div class="-balance"><div class="-transparent -float-left">{{ 'general.iniialHours' | translate }}:&nbsp;</div><div> {{ output.hours | number:'1.0-0' }}</div></div>
+            <div class="-balance"><div class="-transparent -float-left">{{ 'general.currentHours' | translate }}:&nbsp;</div><div> {{ output.calculated_hours | number:'1.0-0' }}</div></div>
           </div>
         </div>
       </div>

--- a/src/app/components/pages/unspent-outputs/unspent-outputs.component.ts
+++ b/src/app/components/pages/unspent-outputs/unspent-outputs.component.ts
@@ -16,6 +16,7 @@ export class UnspentOutputsComponent implements OnInit {
   address: string;
   outputs: GetCurrentBalanceResponse;
   coins: BigNumber = null;
+  hours: BigNumber = null;
   loadingMsg = '';
   longErrorMsg: string;
 
@@ -38,6 +39,9 @@ export class UnspentOutputsComponent implements OnInit {
 
       this.coins = new BigNumber(0);
       response.head_outputs.map(o => this.coins = this.coins.plus(o.coins));
+
+      this.hours = new BigNumber(0);
+      response.head_outputs.map(o => this.hours = this.hours.plus(o.calculated_hours));
     }, error => {
       if (error.status >= 400 && error.status < 500) {
         this.translate.get(['general.noData', 'unspentOutputs.withoutOutputs']).subscribe((res: string[]) => {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -5,6 +5,7 @@
     "coins": "Coins",
     "iniialHours": "Initial Hours",
     "calculatedHours": "Final Hours",
+    "currentHours": "Current Hours",
     "hours": "Hours",
     "loadingMsg": "Loading...",
     "shortLoadingErrorMsg": "Loading error",
@@ -70,7 +71,8 @@
     "title": "Unspent Outputs",
     "address": "Address",
     "outputsNumber": "# of outputs",
-    "total": "Total",
+    "totalCoins": "Total Coins",
+    "totalHours": "Total Hours",
     "origin": "Origin",
     "date": "Date",
     "withoutOutputs": "Without outputs"


### PR DESCRIPTION
Changes:
- The number of hours is now displayed on the unspent outputs page.
- The information about `/api/currentBalance` was updated in `explorer.go`.
- The e2e tests were updated to be compatible with the changes made.