### PR TITLE
Show more inputs/outputs on the txn details page

### DIFF
--- a/src/app/components/layout/transaction-info/transaction-info.component.ts
+++ b/src/app/components/layout/transaction-info/transaction-info.component.ts
@@ -12,7 +12,6 @@ enum ShowMoreStatus {
   styleUrls: ['./transaction-info.component.scss']
 })
 export class TransactionInfoComponent {
-  private readonly maxInitialElements = 10;
   private transactionInternal: any;
 
   disableClicks = false;
@@ -23,6 +22,8 @@ export class TransactionInfoComponent {
   totalOutputs = 0;
   showMoreOutputs: ShowMoreStatus = ShowMoreStatus.DontShowMore;
   outputsToShow: any[] = [];
+
+  @Input() maxInitialElements = 10;
 
   @Input()
   set transaction(value: any) {

--- a/src/app/components/pages/transaction-detail/transaction-detail.component.html
+++ b/src/app/components/pages/transaction-detail/transaction-detail.component.html
@@ -9,4 +9,4 @@
 
 <app-loading [longErrorMsg]="longErrorMsg" *ngIf="transaction === undefined"></app-loading>
 
-<app-transaction-info *ngIf="transaction" [transaction]="transaction"></app-transaction-info>
+<app-transaction-info *ngIf="transaction" [maxInitialElements]="32" [transaction]="transaction"></app-transaction-info>


### PR DESCRIPTION
Now the txn details page shows up to 32 inputs and outputs, instead of 10